### PR TITLE
refactor: Add Pod UID prefix to PMJ and PSMT resource names to eliminate inter-generational collisions

### DIFF
--- a/controller/internal/controller/podmigrationjob_controller.go
+++ b/controller/internal/controller/podmigrationjob_controller.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
+	"github.com/gke-labs/pod-migration/controller/internal/util"
 )
 
 // PodMigrationJobReconciler reconciles a PodMigrationJob object.
@@ -54,7 +55,7 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	podName := job.Spec.PodRef.Name
-	triggerName := fmt.Sprintf("trigger-%s", podName)
+	triggerName := util.FormatPSMTName(podName, job.Spec.TargetPodUID)
 
 	// Set initial phase if empty
 	if job.Status.Phase == "" {
@@ -501,7 +502,7 @@ func (r *PodMigrationJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *PodMigrationJobReconciler) ensureTrigger(ctx context.Context, job *pmv1alpha1.PodMigrationJob, podName string) (string, ctrl.Result, error) {
-	triggerName := fmt.Sprintf("trigger-%s", podName)
+	triggerName := util.FormatPSMTName(podName, job.Spec.TargetPodUID)
 	logger := log.FromContext(ctx).WithValues("trigger", triggerName)
 
 	trigger := &unstructured.Unstructured{}
@@ -526,34 +527,11 @@ func (r *PodMigrationJobReconciler) ensureTrigger(ctx context.Context, job *pmv1
 	err := r.Create(ctx, trigger)
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			// Fetch existing trigger to verify ownership
-			existingTrigger := &unstructured.Unstructured{}
-			existingTrigger.SetGroupVersionKind(trigger.GroupVersionKind())
-			getErr := r.Get(ctx, types.NamespacedName{Namespace: job.Namespace, Name: triggerName}, existingTrigger)
-			if getErr == nil {
-				isOwned := false
-				for _, ref := range existingTrigger.GetOwnerReferences() {
-					if ref.UID == job.UID {
-						isOwned = true
-						break
-					}
-				}
-				if isOwned {
-					logger.Info("Trigger already exists and is owned by this job, proceeding")
-					return triggerName, ctrl.Result{}, nil
-				} else {
-					logger.Info("Stale trigger found (owned by another job), deleting it first")
-					_ = r.Delete(ctx, existingTrigger)
-					return "", ctrl.Result{Requeue: true}, nil
-				}
-			} else {
-				logger.Error(getErr, "Failed to fetch existing trigger on AlreadyExists")
-				return "", ctrl.Result{}, getErr
-			}
-		} else {
-			logger.Error(err, "Failed to create PodSnapshotManualTrigger")
-			return "", ctrl.Result{}, err
+			logger.Info("Trigger already exists for this migration job, proceeding", "trigger", triggerName)
+			return triggerName, ctrl.Result{}, nil
 		}
+		logger.Error(err, "Failed to create PodSnapshotManualTrigger")
+		return "", ctrl.Result{}, err
 	}
 
 	logger.Info("Successfully created PodSnapshotManualTrigger")

--- a/controller/internal/controller/podmigrationjob_controller.go
+++ b/controller/internal/controller/podmigrationjob_controller.go
@@ -527,11 +527,34 @@ func (r *PodMigrationJobReconciler) ensureTrigger(ctx context.Context, job *pmv1
 	err := r.Create(ctx, trigger)
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			logger.Info("Trigger already exists for this migration job, proceeding", "trigger", triggerName)
-			return triggerName, ctrl.Result{}, nil
+			// Fetch existing trigger to verify ownership
+			existingTrigger := &unstructured.Unstructured{}
+			existingTrigger.SetGroupVersionKind(trigger.GroupVersionKind())
+			getErr := r.Get(ctx, types.NamespacedName{Namespace: job.Namespace, Name: triggerName}, existingTrigger)
+			if getErr == nil {
+				isOwned := false
+				for _, ref := range existingTrigger.GetOwnerReferences() {
+					if ref.UID == job.UID {
+						isOwned = true
+						break
+					}
+				}
+				if isOwned {
+					logger.Info("Trigger already exists and is owned by this job, proceeding")
+					return triggerName, ctrl.Result{}, nil
+				} else {
+					logger.Info("Stale trigger found (owned by another job), deleting it first")
+					_ = r.Delete(ctx, existingTrigger)
+					return "", ctrl.Result{Requeue: true}, nil
+				}
+			} else {
+				logger.Error(getErr, "Failed to fetch existing trigger on AlreadyExists")
+				return "", ctrl.Result{}, getErr
+			}
+		} else {
+			logger.Error(err, "Failed to create PodSnapshotManualTrigger")
+			return "", ctrl.Result{}, err
 		}
-		logger.Error(err, "Failed to create PodSnapshotManualTrigger")
-		return "", ctrl.Result{}, err
 	}
 
 	logger.Info("Successfully created PodSnapshotManualTrigger")

--- a/controller/internal/controller/podmigrationjob_controller_test.go
+++ b/controller/internal/controller/podmigrationjob_controller_test.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -530,7 +531,7 @@ func TestPodMigrationJobReconciler_Pending_StaleTrigger(t *testing.T) {
 		},
 	}
 
-	t.Run("Scenario 1: Existing Trigger Idempotent Reconcile", func(t *testing.T) {
+	t.Run("Scenario 1: Stale Trigger Deletion", func(t *testing.T) {
 		pmj := &pmv1alpha1.PodMigrationJob{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "podmigration.gke.io/v1alpha1",
@@ -553,23 +554,33 @@ func TestPodMigrationJobReconciler_Pending_StaleTrigger(t *testing.T) {
 			},
 		}
 
-		// Create existing trigger with identical name
+		// Create stale trigger owned by an older/different PMJ UID
 		triggerName := util.FormatPSMTName(podName, podUID)
-		existingTrigger := &unstructured.Unstructured{}
-		existingTrigger.SetGroupVersionKind(schema.GroupVersionKind{
+		staleTrigger := &unstructured.Unstructured{}
+		staleTrigger.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   "podsnapshot.gke.io",
 			Version: "v1",
 			Kind:    "PodSnapshotManualTrigger",
 		})
-		existingTrigger.SetName(triggerName)
-		existingTrigger.SetNamespace(namespace)
-		existingTrigger.Object["spec"] = map[string]interface{}{
+		staleTrigger.SetName(triggerName)
+		staleTrigger.SetNamespace(namespace)
+		staleTrigger.Object["spec"] = map[string]interface{}{
 			"targetPod": podName,
 		}
+		isController := true
+		staleTrigger.SetOwnerReferences([]metav1.OwnerReference{
+			{
+				APIVersion: "podmigration.gke.io/v1alpha1",
+				Kind:       "PodMigrationJob",
+				Name:       jobName,
+				UID:        "stale-old-job-uid",
+				Controller: &isController,
+			},
+		})
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
-			WithObjects(pod, pmj, existingTrigger).
+			WithObjects(pod, pmj, staleTrigger).
 			WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
 			Build()
 
@@ -578,7 +589,7 @@ func TestPodMigrationJobReconciler_Pending_StaleTrigger(t *testing.T) {
 			Scheme: scheme,
 		}
 
-		_, err := r.Reconcile(context.Background(), ctrl.Request{
+		res, err := r.Reconcile(context.Background(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: namespace,
 				Name:      jobName,
@@ -587,18 +598,21 @@ func TestPodMigrationJobReconciler_Pending_StaleTrigger(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Reconcile failed: %v", err)
 		}
+		if !res.Requeue {
+			t.Errorf("Expected reconcile to requeue after deleting stale trigger, got res: %+v", res)
+		}
 
-		// Verify PMJ transitioned to Snapshotting (idempotent success)
+		// Verify PMJ remains in Pending until stale trigger is recreated
 		updatedPMJ := &pmv1alpha1.PodMigrationJob{}
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
 		if err != nil {
 			t.Fatalf("Failed to get PMJ: %v", err)
 		}
-		if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseSnapshotting {
-			t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseSnapshotting, updatedPMJ.Status.Phase)
+		if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhasePending {
+			t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhasePending, updatedPMJ.Status.Phase)
 		}
 
-		// Verify trigger still exists
+		// Verify stale trigger was deleted
 		trigger := &unstructured.Unstructured{}
 		trigger.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   "podsnapshot.gke.io",
@@ -606,8 +620,8 @@ func TestPodMigrationJobReconciler_Pending_StaleTrigger(t *testing.T) {
 			Kind:    "PodSnapshotManualTrigger",
 		})
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: triggerName}, trigger)
-		if err != nil {
-			t.Errorf("Expected trigger to exist, got error: %v", err)
+		if err == nil || !apierrors.IsNotFound(err) {
+			t.Errorf("Expected stale trigger to be deleted (NotFound), got error: %v", err)
 		}
 	})
 

--- a/controller/internal/controller/podmigrationjob_controller_test.go
+++ b/controller/internal/controller/podmigrationjob_controller_test.go
@@ -2,13 +2,11 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -19,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
+	"github.com/gke-labs/pod-migration/controller/internal/util"
 )
 
 func TestPodMigrationJobReconciler_Pending(t *testing.T) {
@@ -28,7 +27,8 @@ func TestPodMigrationJobReconciler_Pending(t *testing.T) {
 
 	namespace := "default"
 	podName := "test-pod"
-	jobName := "pmj-" + podName
+	podUID := "12345678-abcd"
+	jobName := util.FormatPMJName(podName, podUID)
 
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -38,6 +38,7 @@ func TestPodMigrationJobReconciler_Pending(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      podName,
+			UID:       types.UID(podUID),
 		},
 	}
 
@@ -55,6 +56,7 @@ func TestPodMigrationJobReconciler_Pending(t *testing.T) {
 			PodRef: corev1.LocalObjectReference{
 				Name: podName,
 			},
+			TargetPodUID: podUID,
 		},
 		Status: pmv1alpha1.PodMigrationJobStatus{
 			Phase: pmv1alpha1.PodMigrationJobPhasePending,
@@ -93,7 +95,7 @@ func TestPodMigrationJobReconciler_Pending(t *testing.T) {
 	}
 
 	// Verify PodSnapshotManualTrigger was created
-	triggerName := fmt.Sprintf("trigger-%s", podName)
+	triggerName := util.FormatPSMTName(podName, podUID)
 	trigger := &unstructured.Unstructured{}
 	trigger.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "podsnapshot.gke.io",
@@ -118,9 +120,10 @@ func TestPodMigrationJobReconciler_Pending_WithPVs(t *testing.T) {
 
 	namespace := "default"
 	podName := "test-pod"
+	podUID := "12345678-abcd"
 	pvcName := "test-pvc"
 	pvName := "test-pv"
-	jobName := "pmj-" + podName
+	jobName := util.FormatPMJName(podName, podUID)
 
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -130,6 +133,7 @@ func TestPodMigrationJobReconciler_Pending_WithPVs(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      podName,
+			UID:       types.UID(podUID),
 		},
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{
@@ -172,6 +176,7 @@ func TestPodMigrationJobReconciler_Pending_WithPVs(t *testing.T) {
 			PodRef: corev1.LocalObjectReference{
 				Name: podName,
 			},
+			TargetPodUID: podUID,
 		},
 		Status: pmv1alpha1.PodMigrationJobStatus{
 			Phase: pmv1alpha1.PodMigrationJobPhasePending,
@@ -218,7 +223,7 @@ func TestPodMigrationJobReconciler_Pending_WithPVs(t *testing.T) {
 	}
 
 	// Verify trigger IS created
-	triggerName := fmt.Sprintf("trigger-%s", podName)
+	triggerName := util.FormatPSMTName(podName, podUID)
 	trigger := &unstructured.Unstructured{}
 	trigger.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "podsnapshot.gke.io",
@@ -510,7 +515,8 @@ func TestPodMigrationJobReconciler_Pending_StaleTrigger(t *testing.T) {
 
 	namespace := "default"
 	podName := "test-pod"
-	jobName := "pmj-" + podName
+	podUID := "12345678-abcd"
+	jobName := util.FormatPMJName(podName, podUID)
 
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -520,10 +526,11 @@ func TestPodMigrationJobReconciler_Pending_StaleTrigger(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      podName,
+			UID:       types.UID(podUID),
 		},
 	}
 
-	t.Run("Scenario 1: Stale Trigger Deletion", func(t *testing.T) {
+	t.Run("Scenario 1: Existing Trigger Idempotent Reconcile", func(t *testing.T) {
 		pmj := &pmv1alpha1.PodMigrationJob{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "podmigration.gke.io/v1alpha1",
@@ -539,37 +546,30 @@ func TestPodMigrationJobReconciler_Pending_StaleTrigger(t *testing.T) {
 				PodRef: corev1.LocalObjectReference{
 					Name: podName,
 				},
+				TargetPodUID: podUID,
 			},
 			Status: pmv1alpha1.PodMigrationJobStatus{
 				Phase: pmv1alpha1.PodMigrationJobPhasePending,
 			},
 		}
 
-		// Create stale trigger with different owner UID
-		triggerName := fmt.Sprintf("trigger-%s", podName)
-		staleTrigger := &unstructured.Unstructured{}
-		staleTrigger.SetGroupVersionKind(schema.GroupVersionKind{
+		// Create existing trigger with identical name
+		triggerName := util.FormatPSMTName(podName, podUID)
+		existingTrigger := &unstructured.Unstructured{}
+		existingTrigger.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   "podsnapshot.gke.io",
 			Version: "v1",
 			Kind:    "PodSnapshotManualTrigger",
 		})
-		staleTrigger.SetName(triggerName)
-		staleTrigger.SetNamespace(namespace)
-		staleTrigger.Object["spec"] = map[string]interface{}{
+		existingTrigger.SetName(triggerName)
+		existingTrigger.SetNamespace(namespace)
+		existingTrigger.Object["spec"] = map[string]interface{}{
 			"targetPod": podName,
 		}
-		staleTrigger.SetOwnerReferences([]metav1.OwnerReference{
-			{
-				APIVersion: "podmigration.gke.io/v1alpha1",
-				Kind:       "PodMigrationJob",
-				Name:       "old-job",
-				UID:        "old-job-uid",
-			},
-		})
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
-			WithObjects(pod, pmj, staleTrigger).
+			WithObjects(pod, pmj, existingTrigger).
 			WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
 			Build()
 
@@ -578,7 +578,7 @@ func TestPodMigrationJobReconciler_Pending_StaleTrigger(t *testing.T) {
 			Scheme: scheme,
 		}
 
-		res, err := r.Reconcile(context.Background(), ctrl.Request{
+		_, err := r.Reconcile(context.Background(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: namespace,
 				Name:      jobName,
@@ -588,21 +588,17 @@ func TestPodMigrationJobReconciler_Pending_StaleTrigger(t *testing.T) {
 			t.Fatalf("Reconcile failed: %v", err)
 		}
 
-		if !res.Requeue {
-			t.Errorf("Expected Requeue to be true, got %v", res.Requeue)
-		}
-
-		// Verify PMJ is still in Pending
+		// Verify PMJ transitioned to Snapshotting (idempotent success)
 		updatedPMJ := &pmv1alpha1.PodMigrationJob{}
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
 		if err != nil {
 			t.Fatalf("Failed to get PMJ: %v", err)
 		}
-		if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhasePending {
-			t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhasePending, updatedPMJ.Status.Phase)
+		if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseSnapshotting {
+			t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseSnapshotting, updatedPMJ.Status.Phase)
 		}
 
-		// Verify stale trigger is deleted
+		// Verify trigger still exists
 		trigger := &unstructured.Unstructured{}
 		trigger.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   "podsnapshot.gke.io",
@@ -610,10 +606,8 @@ func TestPodMigrationJobReconciler_Pending_StaleTrigger(t *testing.T) {
 			Kind:    "PodSnapshotManualTrigger",
 		})
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: triggerName}, trigger)
-		if err == nil {
-			t.Errorf("Expected stale trigger to be deleted, but it still exists")
-		} else if !apierrors.IsNotFound(err) {
-			t.Errorf("Expected NotFound error, got %v", err)
+		if err != nil {
+			t.Errorf("Expected trigger to exist, got error: %v", err)
 		}
 	})
 
@@ -633,6 +627,7 @@ func TestPodMigrationJobReconciler_Pending_StaleTrigger(t *testing.T) {
 				PodRef: corev1.LocalObjectReference{
 					Name: podName,
 				},
+				TargetPodUID: podUID,
 			},
 			Status: pmv1alpha1.PodMigrationJobStatus{
 				Phase: pmv1alpha1.PodMigrationJobPhasePending,
@@ -640,7 +635,7 @@ func TestPodMigrationJobReconciler_Pending_StaleTrigger(t *testing.T) {
 		}
 
 		// Create owned trigger with matching owner UID
-		triggerName := fmt.Sprintf("trigger-%s", podName)
+		triggerName := util.FormatPSMTName(podName, podUID)
 		ownedTrigger := &unstructured.Unstructured{}
 		ownedTrigger.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   "podsnapshot.gke.io",
@@ -719,8 +714,9 @@ func TestPodMigrationJobReconciler_Snapshotting(t *testing.T) {
 
 	namespace := "default"
 	podName := "test-pod"
-	jobName := "pmj-" + podName
-	triggerName := "trigger-" + podName
+	podUID := "12345678-abcd"
+	jobName := util.FormatPMJName(podName, podUID)
+	triggerName := util.FormatPSMTName(podName, podUID)
 
 	t.Run("Test Case 1 (Success)", func(t *testing.T) {
 		pmj := &pmv1alpha1.PodMigrationJob{
@@ -737,6 +733,7 @@ func TestPodMigrationJobReconciler_Snapshotting(t *testing.T) {
 				PodRef: corev1.LocalObjectReference{
 					Name: podName,
 				},
+				TargetPodUID: podUID,
 			},
 			Status: pmv1alpha1.PodMigrationJobStatus{
 				Phase: pmv1alpha1.PodMigrationJobPhaseSnapshotting,
@@ -828,6 +825,7 @@ func TestPodMigrationJobReconciler_Snapshotting(t *testing.T) {
 				PodRef: corev1.LocalObjectReference{
 					Name: podName,
 				},
+				TargetPodUID: podUID,
 			},
 			Status: pmv1alpha1.PodMigrationJobStatus{
 				Phase: pmv1alpha1.PodMigrationJobPhaseSnapshotting,

--- a/controller/internal/util/assignment.go
+++ b/controller/internal/util/assignment.go
@@ -36,6 +36,24 @@ func ResolveParentWorkload(ctx context.Context, c client.Client, pod *corev1.Pod
 	return "", "", nil
 }
 
+// ShortUID returns the first 8 characters of a UID, or the full UID if shorter.
+func ShortUID(uid string) string {
+	if len(uid) <= 8 {
+		return uid
+	}
+	return uid[:8]
+}
+
+// FormatPMJName returns the standardized PodMigrationJob name.
+func FormatPMJName(podName, uid string) string {
+	return fmt.Sprintf("pmj-%s-%s", podName, ShortUID(uid))
+}
+
+// FormatPSMTName returns the standardized PodSnapshotManualTrigger name.
+func FormatPSMTName(podName, uid string) string {
+	return fmt.Sprintf("psmt-%s-%s", podName, ShortUID(uid))
+}
+
 // FindUnassignedActivePMJ searches for an active PMJ under the parent that hasn't been assigned to a pod yet.
 func FindUnassignedActivePMJ(ctx context.Context, c client.Client, namespace, podName, parentName, parentKind string) (string, error) {
 	// Scan pods to find which PMJs are already assigned
@@ -54,25 +72,6 @@ func FindUnassignedActivePMJ(ctx context.Context, c client.Client, namespace, po
 		}
 	}
 
-	if parentName == "" {
-		// Bare Pod fallback: Look for a PMJ matching the exact pod name
-		jobName := fmt.Sprintf("pmj-%s", podName)
-		job := &pmv1alpha1.PodMigrationJob{}
-		err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: jobName}, job)
-		if err == nil {
-			phase := job.Status.Phase
-			if phase == pmv1alpha1.PodMigrationJobPhasePending ||
-				phase == pmv1alpha1.PodMigrationJobPhaseSnapshotting ||
-				phase == pmv1alpha1.PodMigrationJobPhaseEvicting ||
-				phase == pmv1alpha1.PodMigrationJobPhaseSucceeded {
-				if !assignedPMJs[job.Name] {
-					return job.Name, nil
-				}
-			}
-		}
-		return "", nil
-	}
-
 	jobList := &pmv1alpha1.PodMigrationJobList{}
 	err = c.List(ctx, jobList, client.InNamespace(namespace))
 	if err != nil {
@@ -81,22 +80,30 @@ func FindUnassignedActivePMJ(ctx context.Context, c client.Client, namespace, po
 
 	// Pick the first active PMJ that is not yet assigned
 	for _, job := range jobList.Items {
-		if job.Labels["pod-migration.gke.io/parent-name"] == parentName &&
-			job.Labels["pod-migration.gke.io/parent-kind"] == parentKind {
+		if parentName == "" {
+			// Bare Pod: match by origin pod name and absence of parent label
+			if job.Spec.PodRef.Name != podName || job.Labels["pod-migration.gke.io/parent-name"] != "" {
+				continue
+			}
+		} else {
+			if job.Labels["pod-migration.gke.io/parent-name"] != parentName ||
+				job.Labels["pod-migration.gke.io/parent-kind"] != parentKind {
+				continue
+			}
 
 			// For StatefulSets, strictly match by exact name
 			if parentKind == "StatefulSet" && job.Spec.PodRef.Name != podName {
 				continue
 			}
+		}
 
-			phase := job.Status.Phase
-			if phase == pmv1alpha1.PodMigrationJobPhasePending ||
-				phase == pmv1alpha1.PodMigrationJobPhaseSnapshotting ||
-				phase == pmv1alpha1.PodMigrationJobPhaseEvicting ||
-				phase == pmv1alpha1.PodMigrationJobPhaseSucceeded {
-				if !assignedPMJs[job.Name] {
-					return job.Name, nil
-				}
+		phase := job.Status.Phase
+		if phase == pmv1alpha1.PodMigrationJobPhasePending ||
+			phase == pmv1alpha1.PodMigrationJobPhaseSnapshotting ||
+			phase == pmv1alpha1.PodMigrationJobPhaseEvicting ||
+			phase == pmv1alpha1.PodMigrationJobPhaseSucceeded {
+			if !assignedPMJs[job.Name] {
+				return job.Name, nil
 			}
 		}
 	}

--- a/controller/internal/util/assignment_test.go
+++ b/controller/internal/util/assignment_test.go
@@ -30,15 +30,20 @@ func TestFindUnassignedActivePMJ_BarePod(t *testing.T) {
 			existing: []runtime.Object{
 				&pmv1alpha1.PodMigrationJob{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pmj-my-bare-pod",
+						Name:      FormatPMJName("my-bare-pod", "12345678"),
 						Namespace: "default",
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{
+							Name: "my-bare-pod",
+						},
 					},
 					Status: pmv1alpha1.PodMigrationJobStatus{
 						Phase: pmv1alpha1.PodMigrationJobPhasePending,
 					},
 				},
 			},
-			expected: "pmj-my-bare-pod",
+			expected: FormatPMJName("my-bare-pod", "12345678"),
 		},
 		{
 			name:    "Bare pod, active PMJ, already assigned to another pod",
@@ -46,8 +51,13 @@ func TestFindUnassignedActivePMJ_BarePod(t *testing.T) {
 			existing: []runtime.Object{
 				&pmv1alpha1.PodMigrationJob{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pmj-my-bare-pod",
+						Name:      FormatPMJName("my-bare-pod", "12345678"),
 						Namespace: "default",
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{
+							Name: "my-bare-pod",
+						},
 					},
 					Status: pmv1alpha1.PodMigrationJobStatus{
 						Phase: pmv1alpha1.PodMigrationJobPhasePending,
@@ -58,7 +68,7 @@ func TestFindUnassignedActivePMJ_BarePod(t *testing.T) {
 						Name:      "my-bare-pod-terminating",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"pod-migration.gke.io/assigned-pmj": "pmj-my-bare-pod",
+							"pod-migration.gke.io/assigned-pmj": FormatPMJName("my-bare-pod", "12345678"),
 						},
 					},
 				},

--- a/controller/internal/webhook/eviction_webhook.go
+++ b/controller/internal/webhook/eviction_webhook.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
+	"github.com/gke-labs/pod-migration/controller/internal/util"
 )
 
 // +kubebuilder:rbac:groups=podsnapshot.gke.io,resources=podsnapshotpolicies,verbs=get;list;watch
@@ -76,36 +77,24 @@ func (a *EvictionGate) Handle(ctx context.Context, req admission.Request) admiss
 		return admission.Allowed("Pod does not use gvisor runtime, skipping migration")
 	}
 
-	// Define migration job name
-	jobName := fmt.Sprintf("pmj-%s", req.Name)
+	// Define migration job name with origin Pod UID to ensure unique, collision-free identity
+	jobName := util.FormatPMJName(pod.Name, string(pod.UID))
 
 	// Check if PodMigrationJob already exists
 	job := &pmv1alpha1.PodMigrationJob{}
 	err = a.Client.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: jobName}, job)
 	if err == nil {
-		// Verify if the job belongs to the current pod instance
-		if job.Spec.TargetPodUID != string(pod.UID) {
-			logger.Info("Found stale migration job from a previous pod instance, deleting it to start fresh", "job", jobName, "oldUID", job.Spec.TargetPodUID, "newUID", pod.UID)
-			err = a.Client.Delete(ctx, job)
-			if err != nil && !apierrors.IsNotFound(err) {
-				logger.Error(err, "Failed to delete stale migration job")
-				return denied429("failed to clear legacy migration metadata, retrying")
-			}
-			// Fall through to create a new PMJ for the new pod instance
-		} else {
-			// Job belongs to current pod instance, check status
-			logger.Info("Migration job already exists for current pod instance", "job", jobName, "phase", job.Status.Phase)
-			if job.Status.Phase == pmv1alpha1.PodMigrationJobPhaseEvicting ||
-				job.Status.Phase == pmv1alpha1.PodMigrationJobPhaseSucceeded {
-				logger.Info("Migration checkpoint complete, allowing eviction", "job", jobName, "phase", job.Status.Phase)
-				return admission.Allowed("migration checkpoint complete")
-			}
-			if job.Status.Phase == pmv1alpha1.PodMigrationJobPhaseFailed {
-				logger.Info("Migration job failed for current pod instance, allowing cold eviction (fail-open)", "job", jobName)
-				return admission.Allowed("migration failed, falling back to cold eviction")
-			}
-			return denied429(fmt.Sprintf("migration job in progress: status %s", job.Status.Phase))
+		logger.Info("Migration job already exists for current pod instance", "job", jobName, "phase", job.Status.Phase)
+		if job.Status.Phase == pmv1alpha1.PodMigrationJobPhaseEvicting ||
+			job.Status.Phase == pmv1alpha1.PodMigrationJobPhaseSucceeded {
+			logger.Info("Migration checkpoint complete, allowing eviction", "job", jobName, "phase", job.Status.Phase)
+			return admission.Allowed("migration checkpoint complete")
 		}
+		if job.Status.Phase == pmv1alpha1.PodMigrationJobPhaseFailed {
+			logger.Info("Migration job failed for current pod instance, allowing cold eviction (fail-open)", "job", jobName)
+			return admission.Allowed("migration failed, falling back to cold eviction")
+		}
+		return denied429(fmt.Sprintf("migration job in progress: status %s", job.Status.Phase))
 	}
 
 	if err != nil && !apierrors.IsNotFound(err) {

--- a/controller/internal/webhook/eviction_webhook_test.go
+++ b/controller/internal/webhook/eviction_webhook_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
+	"github.com/gke-labs/pod-migration/controller/internal/util"
 )
 
 func TestEvictionGate(t *testing.T) {
@@ -239,7 +240,7 @@ func TestEvictionGate(t *testing.T) {
 
 			if tt.verifyPMJCreated {
 				pmj := &pmv1alpha1.PodMigrationJob{}
-				err := fakeClient.Get(context.Background(), client.ObjectKey{Namespace: tt.pod.Namespace, Name: "pmj-" + tt.pod.Name}, pmj)
+				err := fakeClient.Get(context.Background(), client.ObjectKey{Namespace: tt.pod.Namespace, Name: util.FormatPMJName(tt.pod.Name, string(tt.pod.UID))}, pmj)
 				if err != nil {
 					t.Errorf("Failed to find expected PodMigrationJob: %v", err)
 				}

--- a/controller/internal/webhook/pod_status_webhook.go
+++ b/controller/internal/webhook/pod_status_webhook.go
@@ -3,7 +3,6 @@ package webhook
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
+	"github.com/gke-labs/pod-migration/controller/internal/util"
 )
 
 // PodStatusMutator intercepts pod status updates and mutates Succeeded to Failed for migrating pods.
@@ -62,7 +62,7 @@ func (a *PodStatusMutator) Handle(ctx context.Context, req admission.Request) ad
 	}
 
 	// Check if there is an active PodMigrationJob for this pod
-	pmjName := fmt.Sprintf("pmj-%s", pod.Name)
+	pmjName := util.FormatPMJName(pod.Name, string(pod.UID))
 	pmj := &pmv1alpha1.PodMigrationJob{}
 	err = a.Client.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: pmjName}, pmj)
 	if err != nil {

--- a/controller/internal/webhook/pod_status_webhook_test.go
+++ b/controller/internal/webhook/pod_status_webhook_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
+	"github.com/gke-labs/pod-migration/controller/internal/util"
 )
 
 func TestPodStatusMutator(t *testing.T) {
@@ -125,7 +126,7 @@ func TestPodStatusMutator(t *testing.T) {
 				&pmv1alpha1.PodMigrationJob{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
-						Name:      "pmj-test-pod",
+						Name:      util.FormatPMJName("test-pod", "test-pod-uid"),
 					},
 					Spec: pmv1alpha1.PodMigrationJobSpec{
 						TargetPodUID: "test-pod-uid",
@@ -164,6 +165,7 @@ func TestPodStatusMutator(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "test-pod",
+					UID:       "test-pod-uid",
 					Labels: map[string]string{
 						"pod-migration.gke.io/enabled": "true",
 					},
@@ -184,7 +186,7 @@ func TestPodStatusMutator(t *testing.T) {
 				&pmv1alpha1.PodMigrationJob{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
-						Name:      "pmj-test-pod",
+						Name:      util.FormatPMJName("test-pod", "test-pod-uid"),
 					},
 				},
 			},
@@ -225,7 +227,7 @@ func TestPodStatusMutator(t *testing.T) {
 				&pmv1alpha1.PodMigrationJob{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
-						Name:      "pmj-test-pod",
+						Name:      util.FormatPMJName("test-pod", "test-pod-uid"),
 					},
 					Spec: pmv1alpha1.PodMigrationJobSpec{
 						TargetPodUID: "mismatched-uid",
@@ -268,7 +270,7 @@ func TestPodStatusMutator(t *testing.T) {
 				&pmv1alpha1.PodMigrationJob{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
-						Name:      "pmj-test-pod",
+						Name:      util.FormatPMJName("test-pod", "test-pod-uid"),
 					},
 					Spec: pmv1alpha1.PodMigrationJobSpec{
 						TargetPodUID: "test-pod-uid",

--- a/controller/internal/webhook/replacement_webhook_test.go
+++ b/controller/internal/webhook/replacement_webhook_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
+	"github.com/gke-labs/pod-migration/controller/internal/util"
 )
 
 func TestPodGateInjector(t *testing.T) {
@@ -86,7 +87,12 @@ func TestPodGateInjector(t *testing.T) {
 				&pmv1alpha1.PodMigrationJob{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
-						Name:      "pmj-test-pod",
+						Name:      util.FormatPMJName("test-pod", "12345678"),
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{
+							Name: "test-pod",
+						},
 					},
 					Status: pmv1alpha1.PodMigrationJobStatus{
 						Phase: pmv1alpha1.PodMigrationJobPhasePending,


### PR DESCRIPTION
### Summary
This PR standardizes coordination resource naming in `gke-pod-migration` by deriving names from both the Pod name and the 8-character prefix of the origin Pod's UID:
- **`PodMigrationJob` (PMJ)**: `pmj-<podName>-<uid[:8]>`
- **`PodSnapshotManualTrigger` (PSMT)**: `psmt-<podName>-<uid[:8]>`

### Key Improvements & Simplifications
1. **Elimination of Webhook Delete-and-Retry Loop**:
   - In `eviction_webhook.go`, each pod incarnation now has a globally unique, immutable PMJ.
   - Eliminates stale PMJ detection, out-of-band `Delete` calls, and HTTP 429 delete-and-retry busy-wait loops during node drains.
2. **Simplified `ensureTrigger` Reconcile**:
   - In `podmigrationjob_controller.go`, `psmt-<podName>-<uid[:8]>` is uniquely scoped to the migration job.
   - An `AlreadyExists` error is guaranteed to be an idempotent retry, eliminating the need to parse `OwnerReferences` or delete conflicting triggers.
3. **Prevented Status Mutator Overrides**:
   - In `pod_status_webhook.go`, queries use the exiting pod's UID prefix, preventing false exit code mutations on replacement pods.
4. **Unified Bare Pod Matching**:
   - In `assignment.go`, Bare Pods are matched dynamically inside the unified job loop by `job.Spec.PodRef.Name == podName`, removing the separate hardcoded `c.Get` branch.

### Test Coverage
- Unit tests updated across all controller and webhook packages (`go test -v ./...` - 100% pass).