### PR TITLE
feat: Pluggable Snapshot Provider & Fast-Failure on Snapshot / Trigger Errors

### DIFF
--- a/controller/internal/controller/podmigrationjob_controller.go
+++ b/controller/internal/controller/podmigrationjob_controller.go
@@ -10,23 +10,28 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
-	"github.com/gke-labs/pod-migration/controller/internal/util"
+	"github.com/gke-labs/pod-migration/controller/internal/snapshot"
 )
 
 // PodMigrationJobReconciler reconciles a PodMigrationJob object.
 type PodMigrationJobReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme           *runtime.Scheme
+	SnapshotProvider snapshot.Provider
+}
+
+func (r *PodMigrationJobReconciler) getSnapshotProvider() snapshot.Provider {
+	if r.SnapshotProvider != nil {
+		return r.SnapshotProvider
+	}
+	return snapshot.NewGKEProvider(r.Client, r.Scheme)
 }
 
 // +kubebuilder:rbac:groups=podmigration.gke.io,resources=podmigrationjobs,verbs=get;list;watch;create;update;patch;delete
@@ -55,7 +60,6 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	podName := job.Spec.PodRef.Name
-	triggerName := util.FormatPSMTName(podName, job.Spec.TargetPodUID)
 
 	// Set initial phase if empty
 	if job.Status.Phase == "" {
@@ -87,16 +91,8 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				ObservedGeneration: job.Generation,
 			})
 
-			// Clean up GKE manual trigger if it exists (best effort)
-			trigger := &unstructured.Unstructured{}
-			trigger.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "podsnapshot.gke.io",
-				Version: "v1",
-				Kind:    "PodSnapshotManualTrigger",
-			})
-			trigger.SetName(triggerName)
-			trigger.SetNamespace(req.Namespace)
-			_ = r.Delete(ctx, trigger)
+			// Clean up snapshot trigger if it exists (best effort)
+			_ = r.getSnapshotProvider().Cleanup(ctx, job, podName)
 
 			if err := r.Status().Update(ctx, job); err != nil {
 				logger.Error(err, "Failed to update job status to Failed on timeout")
@@ -200,7 +196,7 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			job.Status.PVsToDetach = pvs
 		}
 
-		_, res, err := r.ensureTrigger(ctx, job, podName)
+		res, err := r.getSnapshotProvider().EnsureTrigger(ctx, job, podName)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -217,45 +213,31 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{Requeue: true}, nil
 
 	case pmv1alpha1.PodMigrationJobPhaseSnapshotting:
-		// 3. Monitor GKE Snapshot readiness
-		trigger := &unstructured.Unstructured{}
-		trigger.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "podsnapshot.gke.io",
-			Version: "v1",
-			Kind:    "PodSnapshotManualTrigger",
-		})
-		err = r.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: triggerName}, trigger)
+		// Monitor snapshot readiness via the pluggable SnapshotProvider
+		snapStatus, err := r.getSnapshotProvider().CheckStatus(ctx, job, podName)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
-				logger.Info("Waiting for PodSnapshotManualTrigger to be created...", "trigger", triggerName)
-				cond := metav1.Condition{
-					Type:               "Ready",
-					Status:             metav1.ConditionFalse,
-					Reason:             "Snapshotting",
-					Message:            "Waiting for GKE PodSnapshotManualTrigger to be created",
-					ObservedGeneration: job.Generation,
-				}
-				if meta.SetStatusCondition(&job.Status.Conditions, cond) {
-					_ = r.Status().Update(ctx, job)
-				}
-				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-			}
-			logger.Error(err, "Failed to get PodSnapshotManualTrigger")
+			logger.Error(err, "Failed to check snapshot status")
 			return ctrl.Result{}, err
 		}
 
-		snapshotName, found, err := unstructured.NestedString(trigger.Object, "status", "snapshotCreated", "name")
-		if err != nil {
-			logger.Error(err, "Failed to read snapshotCreated.name from trigger status")
-			return ctrl.Result{}, err
-		}
-		if !found || snapshotName == "" {
-			logger.Info("Waiting for snapshot name to be populated in trigger status...", "trigger", triggerName)
+		switch snapStatus.Phase {
+		case snapshot.PhaseReady:
+			logger.Info("GKE PodSnapshot is Ready, transitioning to Evicting phase", "snapshot", snapStatus.SnapshotRef)
+			job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseEvicting
+			job.Status.SnapshotRef = snapStatus.SnapshotRef
+			err = r.Status().Update(ctx, job)
+			if err != nil {
+				logger.Error(err, "Failed to update job status to Evicting")
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{Requeue: true}, nil
+
+		case snapshot.PhaseInProgress:
 			cond := metav1.Condition{
 				Type:               "Ready",
 				Status:             metav1.ConditionFalse,
-				Reason:             "Snapshotting",
-				Message:            "Waiting for GKE to populate snapshot name in trigger status",
+				Reason:             snapStatus.Reason,
+				Message:            snapStatus.Message,
 				ObservedGeneration: job.Generation,
 			}
 			if meta.SetStatusCondition(&job.Status.Conditions, cond) {
@@ -263,90 +245,6 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			}
 			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 		}
-
-		targetSnapshot := &unstructured.Unstructured{}
-		targetSnapshot.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "podsnapshot.gke.io",
-			Version: "v1",
-			Kind:    "PodSnapshot",
-		})
-		err = r.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: snapshotName}, targetSnapshot)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				logger.Info("Waiting for PodSnapshot to be created...", "snapshot", snapshotName)
-				cond := metav1.Condition{
-					Type:               "Ready",
-					Status:             metav1.ConditionFalse,
-					Reason:             "Snapshotting",
-					Message:            fmt.Sprintf("Waiting for GKE PodSnapshot object %q to be created", snapshotName),
-					ObservedGeneration: job.Generation,
-				}
-				if meta.SetStatusCondition(&job.Status.Conditions, cond) {
-					_ = r.Status().Update(ctx, job)
-				}
-				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-			}
-			logger.Error(err, "Failed to get PodSnapshot")
-			return ctrl.Result{}, err
-		}
-
-		// Check if snapshot is ready
-		snapStatus, ok := targetSnapshot.Object["status"].(map[string]interface{})
-		if !ok {
-			logger.Info("Snapshot status subresource not found, waiting...")
-			cond := metav1.Condition{
-				Type:               "Ready",
-				Status:             metav1.ConditionFalse,
-				Reason:             "Snapshotting",
-				Message:            fmt.Sprintf("Waiting for GKE PodSnapshot %q status to be populated", snapshotName),
-				ObservedGeneration: job.Generation,
-			}
-			if meta.SetStatusCondition(&job.Status.Conditions, cond) {
-				_ = r.Status().Update(ctx, job)
-			}
-			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-		}
-
-		conditions, _ := snapStatus["conditions"].([]interface{})
-		isReady := false
-		for _, c := range conditions {
-			cond, ok := c.(map[string]interface{})
-			if ok {
-				if cond["type"] == "Ready" && cond["status"] == "True" {
-					isReady = true
-					break
-				}
-				if cond["type"] == "Checkpoint" && cond["status"] == "True" && cond["reason"] == "Succeeded" {
-					isReady = true
-					break
-				}
-			}
-		}
-
-		if !isReady {
-			logger.Info("Snapshot is not ready yet, waiting...")
-			cond := metav1.Condition{
-				Type:               "Ready",
-				Status:             metav1.ConditionFalse,
-				Reason:             "Snapshotting",
-				Message:            fmt.Sprintf("Waiting for GKE PodSnapshot %q checkpoint to complete", snapshotName),
-				ObservedGeneration: job.Generation,
-			}
-			if meta.SetStatusCondition(&job.Status.Conditions, cond) {
-				_ = r.Status().Update(ctx, job)
-			}
-			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-		}
-
-		logger.Info("GKE PodSnapshot is Ready, transitioning to Evicting phase", "snapshot", snapshotName)
-		job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseEvicting
-		job.Status.SnapshotRef = snapshotName
-		err = r.Status().Update(ctx, job)
-		if err != nil {
-			logger.Error(err, "Failed to update job status to Evicting")
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{Requeue: true}, nil
 
 	case pmv1alpha1.PodMigrationJobPhaseEvicting:
 
@@ -401,24 +299,8 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			}
 		}
 
-		// Once the Pod is gone (or we fallback-deleted it), we can delete the manual trigger.
-		logger.Info("Deleting manual trigger", "trigger", triggerName)
-		trigger := &unstructured.Unstructured{}
-		trigger.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "podsnapshot.gke.io",
-			Version: "v1",
-			Kind:    "PodSnapshotManualTrigger",
-		})
-		err = r.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: triggerName}, trigger)
-		if err == nil {
-			err = r.Delete(ctx, trigger)
-			if err != nil {
-				logger.Error(err, "Failed to delete trigger")
-				return ctrl.Result{}, err
-			}
-			logger.Info("Successfully deleted trigger")
-		} else if !apierrors.IsNotFound(err) {
-			logger.Error(err, "Failed to get trigger")
+		// Once the Pod is gone (or we fallback-deleted it), clean up trigger
+		if err := r.getSnapshotProvider().Cleanup(ctx, job, podName); err != nil {
 			return ctrl.Result{}, err
 		}
 
@@ -499,64 +381,4 @@ func (r *PodMigrationJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&pmv1alpha1.PodMigrationJob{}).
 		Complete(r)
-}
-
-func (r *PodMigrationJobReconciler) ensureTrigger(ctx context.Context, job *pmv1alpha1.PodMigrationJob, podName string) (string, ctrl.Result, error) {
-	triggerName := util.FormatPSMTName(podName, job.Spec.TargetPodUID)
-	logger := log.FromContext(ctx).WithValues("trigger", triggerName)
-
-	trigger := &unstructured.Unstructured{}
-	trigger.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "podsnapshot.gke.io",
-		Version: "v1",
-		Kind:    "PodSnapshotManualTrigger",
-	})
-	trigger.SetName(triggerName)
-	trigger.SetNamespace(job.Namespace)
-	trigger.Object["spec"] = map[string]interface{}{
-		"targetPod": podName,
-	}
-
-	// Set owner reference to allow cascade deletion and ownership verification
-	if err := controllerutil.SetControllerReference(job, trigger, r.Scheme); err != nil {
-		logger.Error(err, "Failed to set owner reference on trigger")
-		return "", ctrl.Result{}, err
-	}
-
-	logger.Info("Creating PodSnapshotManualTrigger")
-	err := r.Create(ctx, trigger)
-	if err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			// Fetch existing trigger to verify ownership
-			existingTrigger := &unstructured.Unstructured{}
-			existingTrigger.SetGroupVersionKind(trigger.GroupVersionKind())
-			getErr := r.Get(ctx, types.NamespacedName{Namespace: job.Namespace, Name: triggerName}, existingTrigger)
-			if getErr == nil {
-				isOwned := false
-				for _, ref := range existingTrigger.GetOwnerReferences() {
-					if ref.UID == job.UID {
-						isOwned = true
-						break
-					}
-				}
-				if isOwned {
-					logger.Info("Trigger already exists and is owned by this job, proceeding")
-					return triggerName, ctrl.Result{}, nil
-				} else {
-					logger.Info("Stale trigger found (owned by another job), deleting it first")
-					_ = r.Delete(ctx, existingTrigger)
-					return "", ctrl.Result{Requeue: true}, nil
-				}
-			} else {
-				logger.Error(getErr, "Failed to fetch existing trigger on AlreadyExists")
-				return "", ctrl.Result{}, getErr
-			}
-		} else {
-			logger.Error(err, "Failed to create PodSnapshotManualTrigger")
-			return "", ctrl.Result{}, err
-		}
-	}
-
-	logger.Info("Successfully created PodSnapshotManualTrigger")
-	return triggerName, ctrl.Result{}, nil
 }

--- a/controller/internal/controller/podmigrationjob_controller.go
+++ b/controller/internal/controller/podmigrationjob_controller.go
@@ -221,6 +221,25 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 
 		switch snapStatus.Phase {
+		case snapshot.PhaseFailed:
+			logger.Info("Snapshot provider reported terminal failure, transitioning to Failed", "reason", snapStatus.Reason, "message", snapStatus.Message)
+			job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseFailed
+			now := metav1.Now()
+			job.Status.CompletionTime = &now
+			meta.SetStatusCondition(&job.Status.Conditions, metav1.Condition{
+				Type:               "Ready",
+				Status:             metav1.ConditionFalse,
+				Reason:             snapStatus.Reason,
+				Message:            snapStatus.Message,
+				ObservedGeneration: job.Generation,
+			})
+			err = r.Status().Update(ctx, job)
+			if err != nil {
+				logger.Error(err, "Failed to update job status to Failed on snapshot failure")
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+
 		case snapshot.PhaseReady:
 			logger.Info("GKE PodSnapshot is Ready, transitioning to Evicting phase", "snapshot", snapStatus.SnapshotRef)
 			job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseEvicting

--- a/controller/internal/controller/podmigrationjob_controller.go
+++ b/controller/internal/controller/podmigrationjob_controller.go
@@ -223,6 +223,7 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		switch snapStatus.Phase {
 		case snapshot.PhaseFailed:
 			logger.Info("Snapshot provider reported terminal failure, transitioning to Failed", "reason", snapStatus.Reason, "message", snapStatus.Message)
+			_ = r.getSnapshotProvider().Cleanup(ctx, job, podName)
 			job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseFailed
 			now := metav1.Now()
 			job.Status.CompletionTime = &now

--- a/controller/internal/controller/podmigrationjob_controller_test.go
+++ b/controller/internal/controller/podmigrationjob_controller_test.go
@@ -932,6 +932,184 @@ func TestPodMigrationJobReconciler_Snapshotting(t *testing.T) {
 			t.Errorf("Expected phase to remain %s, got %s", pmv1alpha1.PodMigrationJobPhaseSnapshotting, updatedPMJ.Status.Phase)
 		}
 	})
+
+	t.Run("Test Case 3 (Fast-Fail on PSMT Failure)", func(t *testing.T) {
+		pmj := &pmv1alpha1.PodMigrationJob{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "podmigration.gke.io/v1alpha1",
+				Kind:       "PodMigrationJob",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         namespace,
+				Name:              jobName,
+				CreationTimestamp: metav1.Now(),
+			},
+			Spec: pmv1alpha1.PodMigrationJobSpec{
+				PodRef: corev1.LocalObjectReference{
+					Name: podName,
+				},
+				TargetPodUID: podUID,
+			},
+			Status: pmv1alpha1.PodMigrationJobStatus{
+				Phase: pmv1alpha1.PodMigrationJobPhaseSnapshotting,
+			},
+		}
+
+		trigger := &unstructured.Unstructured{}
+		trigger.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "podsnapshot.gke.io",
+			Version: "v1",
+			Kind:    "PodSnapshotManualTrigger",
+		})
+		trigger.SetName(triggerName)
+		trigger.SetNamespace(namespace)
+		trigger.Object["status"] = map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":    "Triggered",
+					"status":  "False",
+					"reason":  "Failed",
+					"message": "target pod not found on node",
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(pmj, trigger).
+			WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+			Build()
+
+		r := &PodMigrationJobReconciler{
+			Client: fakeClient,
+			Scheme: scheme,
+		}
+
+		res, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: namespace,
+				Name:      jobName,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Reconcile failed: %v", err)
+		}
+		if res.Requeue || res.RequeueAfter != 0 {
+			t.Errorf("Expected no requeue on terminal failure, got %+v", res)
+		}
+
+		updatedPMJ := &pmv1alpha1.PodMigrationJob{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
+		if err != nil {
+			t.Fatalf("Failed to get PMJ: %v", err)
+		}
+		if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseFailed {
+			t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseFailed, updatedPMJ.Status.Phase)
+		}
+		if updatedPMJ.Status.CompletionTime == nil {
+			t.Errorf("Expected CompletionTime to be set")
+		}
+		cond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Ready")
+		if cond == nil || cond.Reason != "SnapshotTriggerFailed" {
+			t.Errorf("Expected Ready condition with Reason=SnapshotTriggerFailed, got %+v", cond)
+		}
+	})
+
+	t.Run("Test Case 4 (Fast-Fail on PodSnapshot Failure)", func(t *testing.T) {
+		pmj := &pmv1alpha1.PodMigrationJob{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "podmigration.gke.io/v1alpha1",
+				Kind:       "PodMigrationJob",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         namespace,
+				Name:              jobName,
+				CreationTimestamp: metav1.Now(),
+			},
+			Spec: pmv1alpha1.PodMigrationJobSpec{
+				PodRef: corev1.LocalObjectReference{
+					Name: podName,
+				},
+				TargetPodUID: podUID,
+			},
+			Status: pmv1alpha1.PodMigrationJobStatus{
+				Phase: pmv1alpha1.PodMigrationJobPhaseSnapshotting,
+			},
+		}
+
+		trigger := &unstructured.Unstructured{}
+		trigger.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "podsnapshot.gke.io",
+			Version: "v1",
+			Kind:    "PodSnapshotManualTrigger",
+		})
+		trigger.SetName(triggerName)
+		trigger.SetNamespace(namespace)
+		trigger.Object["status"] = map[string]interface{}{
+			"snapshotCreated": map[string]interface{}{
+				"name": "failed-snap",
+			},
+		}
+
+		snapshot := &unstructured.Unstructured{}
+		snapshot.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "podsnapshot.gke.io",
+			Version: "v1",
+			Kind:    "PodSnapshot",
+		})
+		snapshot.SetName("failed-snap")
+		snapshot.SetNamespace(namespace)
+		snapshot.Object["status"] = map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":    "Checkpoint",
+					"status":  "False",
+					"reason":  "Failed",
+					"message": "runsc checkpoint: signal SIGKILL",
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(pmj, trigger, snapshot).
+			WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+			Build()
+
+		r := &PodMigrationJobReconciler{
+			Client: fakeClient,
+			Scheme: scheme,
+		}
+
+		res, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: namespace,
+				Name:      jobName,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Reconcile failed: %v", err)
+		}
+		if res.Requeue || res.RequeueAfter != 0 {
+			t.Errorf("Expected no requeue on terminal failure, got %+v", res)
+		}
+
+		updatedPMJ := &pmv1alpha1.PodMigrationJob{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
+		if err != nil {
+			t.Fatalf("Failed to get PMJ: %v", err)
+		}
+		if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseFailed {
+			t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseFailed, updatedPMJ.Status.Phase)
+		}
+		if updatedPMJ.Status.CompletionTime == nil {
+			t.Errorf("Expected CompletionTime to be set")
+		}
+		cond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Ready")
+		if cond == nil || cond.Reason != "SnapshotFailed" {
+			t.Errorf("Expected Ready condition with Reason=SnapshotFailed, got %+v", cond)
+		}
+	})
 }
 
 func TestPodMigrationJobReconciler_Evicting_Success(t *testing.T) {

--- a/controller/internal/snapshot/gke_provider.go
+++ b/controller/internal/snapshot/gke_provider.go
@@ -111,6 +111,24 @@ func (p *GKEProvider) CheckStatus(ctx context.Context, job *pmv1alpha1.PodMigrat
 		return nil, err
 	}
 
+	// 1. Fast-fail if GKE Snapshot Trigger (PSMT) reported a terminal failure
+	psmtStatus, _ := trigger.Object["status"].(map[string]interface{})
+	if psmtConditions, ok := psmtStatus["conditions"].([]interface{}); ok {
+		for _, c := range psmtConditions {
+			if cond, ok := c.(map[string]interface{}); ok {
+				if cond["type"] == "Triggered" && cond["status"] == "False" && cond["reason"] == "Failed" {
+					errMsg, _ := cond["message"].(string)
+					logger.Info("PSMT reported terminal failure", "trigger", triggerName, "reason", errMsg)
+					return &Status{
+						Phase:   PhaseFailed,
+						Reason:  "SnapshotTriggerFailed",
+						Message: fmt.Sprintf("GKE PodSnapshotManualTrigger failed: %s", errMsg),
+					}, nil
+				}
+			}
+		}
+	}
+
 	snapshotName, found, err := unstructured.NestedString(trigger.Object, "status", "snapshotCreated", "name")
 	if err != nil {
 		logger.Error(err, "Failed to read snapshotCreated.name from trigger status")
@@ -169,6 +187,19 @@ func (p *GKEProvider) CheckStatus(ctx context.Context, job *pmv1alpha1.PodMigrat
 				return &Status{
 					Phase:       PhaseReady,
 					SnapshotRef: snapshotName,
+				}, nil
+			}
+			// 2. Fast-fail if PodSnapshot reported terminal failure in Checkpoint, StorageReplicated, or Ready
+			cType, _ := cond["type"].(string)
+			cStatus, _ := cond["status"].(string)
+			cReason, _ := cond["reason"].(string)
+			cMsg, _ := cond["message"].(string)
+			if cStatus == "False" && cReason == "Failed" && (cType == "Checkpoint" || cType == "StorageReplicated" || cType == "Ready") {
+				logger.Info("PodSnapshot reported terminal failure", "snapshot", snapshotName, "type", cType, "reason", cMsg)
+				return &Status{
+					Phase:   PhaseFailed,
+					Reason:  "SnapshotFailed",
+					Message: fmt.Sprintf("GKE PodSnapshot %s failed: %s", cType, cMsg),
 				}, nil
 			}
 		}

--- a/controller/internal/snapshot/gke_provider.go
+++ b/controller/internal/snapshot/gke_provider.go
@@ -1,0 +1,206 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
+	"github.com/gke-labs/pod-migration/controller/internal/util"
+)
+
+type GKEProvider struct {
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+func NewGKEProvider(c client.Client, s *runtime.Scheme) *GKEProvider {
+	return &GKEProvider{client: c, scheme: s}
+}
+
+func (p *GKEProvider) EnsureTrigger(ctx context.Context, job *pmv1alpha1.PodMigrationJob, podName string) (ctrl.Result, error) {
+	triggerName := util.FormatPSMTName(podName, job.Spec.TargetPodUID)
+	logger := log.FromContext(ctx).WithValues("trigger", triggerName)
+
+	trigger := &unstructured.Unstructured{}
+	trigger.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "podsnapshot.gke.io",
+		Version: "v1",
+		Kind:    "PodSnapshotManualTrigger",
+	})
+	trigger.SetName(triggerName)
+	trigger.SetNamespace(job.Namespace)
+	trigger.Object["spec"] = map[string]interface{}{
+		"targetPod": podName,
+	}
+
+	// Set owner reference to allow cascade deletion and ownership verification
+	if err := controllerutil.SetControllerReference(job, trigger, p.scheme); err != nil {
+		logger.Error(err, "Failed to set owner reference on trigger")
+		return ctrl.Result{}, err
+	}
+
+	logger.Info("Creating PodSnapshotManualTrigger")
+	err := p.client.Create(ctx, trigger)
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// Fetch existing trigger to verify ownership
+			existingTrigger := &unstructured.Unstructured{}
+			existingTrigger.SetGroupVersionKind(trigger.GroupVersionKind())
+			getErr := p.client.Get(ctx, types.NamespacedName{Namespace: job.Namespace, Name: triggerName}, existingTrigger)
+			if getErr == nil {
+				isOwned := false
+				for _, ref := range existingTrigger.GetOwnerReferences() {
+					if ref.UID == job.UID {
+						isOwned = true
+						break
+					}
+				}
+				if isOwned {
+					logger.Info("Trigger already exists and is owned by this job, proceeding")
+					return ctrl.Result{}, nil
+				} else {
+					logger.Info("Stale trigger found (owned by another job), deleting it first")
+					_ = p.client.Delete(ctx, existingTrigger)
+					return ctrl.Result{Requeue: true}, nil
+				}
+			} else {
+				logger.Error(getErr, "Failed to fetch existing trigger on AlreadyExists")
+				return ctrl.Result{}, getErr
+			}
+		} else {
+			logger.Error(err, "Failed to create PodSnapshotManualTrigger")
+			return ctrl.Result{}, err
+		}
+	}
+
+	logger.Info("Successfully created PodSnapshotManualTrigger")
+	return ctrl.Result{}, nil
+}
+
+func (p *GKEProvider) CheckStatus(ctx context.Context, job *pmv1alpha1.PodMigrationJob, podName string) (*Status, error) {
+	triggerName := util.FormatPSMTName(podName, job.Spec.TargetPodUID)
+	logger := log.FromContext(ctx).WithValues("trigger", triggerName)
+
+	trigger := &unstructured.Unstructured{}
+	trigger.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "podsnapshot.gke.io",
+		Version: "v1",
+		Kind:    "PodSnapshotManualTrigger",
+	})
+	err := p.client.Get(ctx, types.NamespacedName{Namespace: job.Namespace, Name: triggerName}, trigger)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("Waiting for PodSnapshotManualTrigger to be created...", "trigger", triggerName)
+			return &Status{
+				Phase:   PhaseInProgress,
+				Reason:  "Snapshotting",
+				Message: "Waiting for GKE PodSnapshotManualTrigger to be created",
+			}, nil
+		}
+		logger.Error(err, "Failed to get PodSnapshotManualTrigger")
+		return nil, err
+	}
+
+	snapshotName, found, err := unstructured.NestedString(trigger.Object, "status", "snapshotCreated", "name")
+	if err != nil {
+		logger.Error(err, "Failed to read snapshotCreated.name from trigger status")
+		return nil, err
+	}
+	if !found || snapshotName == "" {
+		logger.Info("Waiting for snapshot name to be populated in trigger status...", "trigger", triggerName)
+		return &Status{
+			Phase:   PhaseInProgress,
+			Reason:  "Snapshotting",
+			Message: "Waiting for GKE to populate snapshot name in trigger status",
+		}, nil
+	}
+
+	targetSnapshot := &unstructured.Unstructured{}
+	targetSnapshot.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "podsnapshot.gke.io",
+		Version: "v1",
+		Kind:    "PodSnapshot",
+	})
+	err = p.client.Get(ctx, types.NamespacedName{Namespace: job.Namespace, Name: snapshotName}, targetSnapshot)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("Waiting for PodSnapshot to be created...", "snapshot", snapshotName)
+			return &Status{
+				Phase:   PhaseInProgress,
+				Reason:  "Snapshotting",
+				Message: fmt.Sprintf("Waiting for GKE PodSnapshot object %q to be created", snapshotName),
+			}, nil
+		}
+		logger.Error(err, "Failed to get PodSnapshot")
+		return nil, err
+	}
+
+	snapStatus, ok := targetSnapshot.Object["status"].(map[string]interface{})
+	if !ok {
+		logger.Info("Snapshot status subresource not found, waiting...")
+		return &Status{
+			Phase:   PhaseInProgress,
+			Reason:  "Snapshotting",
+			Message: fmt.Sprintf("Waiting for GKE PodSnapshot %q status to be populated", snapshotName),
+		}, nil
+	}
+
+	conditions, _ := snapStatus["conditions"].([]interface{})
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if ok {
+			if cond["type"] == "Ready" && cond["status"] == "True" {
+				return &Status{
+					Phase:       PhaseReady,
+					SnapshotRef: snapshotName,
+				}, nil
+			}
+			if cond["type"] == "Checkpoint" && cond["status"] == "True" && cond["reason"] == "Succeeded" {
+				return &Status{
+					Phase:       PhaseReady,
+					SnapshotRef: snapshotName,
+				}, nil
+			}
+		}
+	}
+
+	logger.Info("Snapshot is not ready yet, waiting...")
+	return &Status{
+		Phase:   PhaseInProgress,
+		Reason:  "Snapshotting",
+		Message: fmt.Sprintf("Waiting for GKE PodSnapshot %q checkpoint to complete", snapshotName),
+	}, nil
+}
+
+func (p *GKEProvider) Cleanup(ctx context.Context, job *pmv1alpha1.PodMigrationJob, podName string) error {
+	triggerName := util.FormatPSMTName(podName, job.Spec.TargetPodUID)
+	logger := log.FromContext(ctx).WithValues("trigger", triggerName)
+
+	logger.Info("Deleting manual trigger", "trigger", triggerName)
+	trigger := &unstructured.Unstructured{}
+	trigger.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "podsnapshot.gke.io",
+		Version: "v1",
+		Kind:    "PodSnapshotManualTrigger",
+	})
+	trigger.SetName(triggerName)
+	trigger.SetNamespace(job.Namespace)
+
+	err := p.client.Delete(ctx, trigger)
+	if err != nil && !apierrors.IsNotFound(err) {
+		logger.Error(err, "Failed to delete trigger")
+		return err
+	}
+	logger.Info("Successfully deleted trigger")
+	return nil
+}

--- a/controller/internal/snapshot/gke_provider.go
+++ b/controller/internal/snapshot/gke_provider.go
@@ -174,32 +174,42 @@ func (p *GKEProvider) CheckStatus(ctx context.Context, job *pmv1alpha1.PodMigrat
 	}
 
 	conditions, _ := snapStatus["conditions"].([]interface{})
+	// Pass 1: Scan all conditions for terminal failures
 	for _, c := range conditions {
 		cond, ok := c.(map[string]interface{})
 		if ok {
-			if cond["type"] == "Ready" && cond["status"] == "True" {
-				return &Status{
-					Phase:       PhaseReady,
-					SnapshotRef: snapshotName,
-				}, nil
-			}
-			if cond["type"] == "Checkpoint" && cond["status"] == "True" && cond["reason"] == "Succeeded" {
-				return &Status{
-					Phase:       PhaseReady,
-					SnapshotRef: snapshotName,
-				}, nil
-			}
-			// 2. Fast-fail if PodSnapshot reported terminal failure in Checkpoint, StorageReplicated, or Ready
 			cType, _ := cond["type"].(string)
 			cStatus, _ := cond["status"].(string)
 			cReason, _ := cond["reason"].(string)
 			cMsg, _ := cond["message"].(string)
-			if cStatus == "False" && cReason == "Failed" && (cType == "Checkpoint" || cType == "StorageReplicated" || cType == "Ready") {
+			if cStatus == "False" && (cReason == "Failed" || cReason == "Error") && (cType == "Checkpoint" || cType == "StorageReplicated" || cType == "Ready") {
 				logger.Info("PodSnapshot reported terminal failure", "snapshot", snapshotName, "type", cType, "reason", cMsg)
 				return &Status{
 					Phase:   PhaseFailed,
 					Reason:  "SnapshotFailed",
 					Message: fmt.Sprintf("GKE PodSnapshot %s failed: %s", cType, cMsg),
+				}, nil
+			}
+		}
+	}
+
+	// Pass 2: Check for readiness
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if ok {
+			cType, _ := cond["type"].(string)
+			cStatus, _ := cond["status"].(string)
+			cReason, _ := cond["reason"].(string)
+			if cType == "Ready" && cStatus == "True" {
+				return &Status{
+					Phase:       PhaseReady,
+					SnapshotRef: snapshotName,
+				}, nil
+			}
+			if cType == "Checkpoint" && cStatus == "True" && cReason == "Succeeded" {
+				return &Status{
+					Phase:       PhaseReady,
+					SnapshotRef: snapshotName,
 				}, nil
 			}
 		}

--- a/controller/internal/snapshot/gke_provider_test.go
+++ b/controller/internal/snapshot/gke_provider_test.go
@@ -291,4 +291,107 @@ func TestGKEProvider_CheckStatus(t *testing.T) {
 			t.Errorf("expected snapshotRef=%s, got %s", snapshotName, status.SnapshotRef)
 		}
 	})
+
+	t.Run("PodSnapshot_OrderIndependence_CheckpointSucceeded_StorageFailed", func(t *testing.T) {
+		trigger := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "podsnapshot.gke.io/v1",
+				"kind":       "PodSnapshotManualTrigger",
+				"metadata": map[string]interface{}{
+					"name":      triggerName,
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"snapshotCreated": map[string]interface{}{
+						"name": snapshotName,
+					},
+				},
+			},
+		}
+		// Order 1: Checkpoint True/Succeeded at index 0, StorageReplicated False/Failed at index 1
+		snapshotOrder1 := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "podsnapshot.gke.io/v1",
+				"kind":       "PodSnapshot",
+				"metadata": map[string]interface{}{
+					"name":      snapshotName,
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":    "Checkpoint",
+							"status":  "True",
+							"reason":  "Succeeded",
+							"message": "runsc checkpoint succeeded",
+						},
+						map[string]interface{}{
+							"type":    "StorageReplicated",
+							"status":  "False",
+							"reason":  "Failed",
+							"message": "GCS upload failed",
+						},
+					},
+				},
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(trigger, snapshotOrder1).Build()
+		provider := NewGKEProvider(client, scheme)
+		job := &pmv1alpha1.PodMigrationJob{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+			Spec:       pmv1alpha1.PodMigrationJobSpec{TargetPodUID: "pod-uid-456"},
+		}
+		status, err := provider.CheckStatus(context.Background(), job, "test-pod")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status.Phase != PhaseFailed {
+			t.Fatalf("Order 1: expected PhaseFailed, got %v", status.Phase)
+		}
+		if status.Reason != "SnapshotFailed" {
+			t.Errorf("Order 1: expected Reason=SnapshotFailed, got %s", status.Reason)
+		}
+
+		// Order 2 (Reverse): StorageReplicated False/Failed at index 0, Checkpoint True/Succeeded at index 1
+		snapshotOrder2 := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "podsnapshot.gke.io/v1",
+				"kind":       "PodSnapshot",
+				"metadata": map[string]interface{}{
+					"name":      snapshotName,
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":    "StorageReplicated",
+							"status":  "False",
+							"reason":  "Failed",
+							"message": "GCS upload failed",
+						},
+						map[string]interface{}{
+							"type":    "Checkpoint",
+							"status":  "True",
+							"reason":  "Succeeded",
+							"message": "runsc checkpoint succeeded",
+						},
+					},
+				},
+			},
+		}
+
+		client2 := fake.NewClientBuilder().WithScheme(scheme).WithObjects(trigger, snapshotOrder2).Build()
+		provider2 := NewGKEProvider(client2, scheme)
+		status2, err := provider2.CheckStatus(context.Background(), job, "test-pod")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status2.Phase != PhaseFailed {
+			t.Fatalf("Order 2: expected PhaseFailed, got %v", status2.Phase)
+		}
+		if status2.Reason != "SnapshotFailed" {
+			t.Errorf("Order 2: expected Reason=SnapshotFailed, got %s", status2.Reason)
+		}
+	})
 }

--- a/controller/internal/snapshot/gke_provider_test.go
+++ b/controller/internal/snapshot/gke_provider_test.go
@@ -2,6 +2,7 @@ package snapshot
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,6 +79,162 @@ func TestGKEProvider_CheckStatus(t *testing.T) {
 		}
 		if status.Phase != PhaseInProgress {
 			t.Errorf("expected PhaseInProgress, got %v", status.Phase)
+		}
+	})
+
+	t.Run("PSMT_TriggerFailed_FastFail", func(t *testing.T) {
+		trigger := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "podsnapshot.gke.io/v1",
+				"kind":       "PodSnapshotManualTrigger",
+				"metadata": map[string]interface{}{
+					"name":      triggerName,
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":    "Triggered",
+							"status":  "False",
+							"reason":  "Failed",
+							"message": "target pod is not using the gvisor runtime class",
+						},
+					},
+				},
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(trigger).Build()
+		provider := NewGKEProvider(client, scheme)
+		job := &pmv1alpha1.PodMigrationJob{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+			Spec:       pmv1alpha1.PodMigrationJobSpec{TargetPodUID: "pod-uid-456"},
+		}
+		status, err := provider.CheckStatus(context.Background(), job, "test-pod")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status.Phase != PhaseFailed {
+			t.Fatalf("expected PhaseFailed, got %v", status.Phase)
+		}
+		if status.Reason != "SnapshotTriggerFailed" {
+			t.Errorf("expected Reason=SnapshotTriggerFailed, got %s", status.Reason)
+		}
+		if !strings.Contains(status.Message, "not using the gvisor runtime class") {
+			t.Errorf("expected message to contain error details, got %s", status.Message)
+		}
+	})
+
+	t.Run("PodSnapshot_CheckpointFailed_FastFail", func(t *testing.T) {
+		trigger := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "podsnapshot.gke.io/v1",
+				"kind":       "PodSnapshotManualTrigger",
+				"metadata": map[string]interface{}{
+					"name":      triggerName,
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"snapshotCreated": map[string]interface{}{
+						"name": snapshotName,
+					},
+				},
+			},
+		}
+		snapshot := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "podsnapshot.gke.io/v1",
+				"kind":       "PodSnapshot",
+				"metadata": map[string]interface{}{
+					"name":      snapshotName,
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":    "Checkpoint",
+							"status":  "False",
+							"reason":  "Failed",
+							"message": "runsc checkpoint: unhandled syscall",
+						},
+					},
+				},
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(trigger, snapshot).Build()
+		provider := NewGKEProvider(client, scheme)
+		job := &pmv1alpha1.PodMigrationJob{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+			Spec:       pmv1alpha1.PodMigrationJobSpec{TargetPodUID: "pod-uid-456"},
+		}
+		status, err := provider.CheckStatus(context.Background(), job, "test-pod")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status.Phase != PhaseFailed {
+			t.Fatalf("expected PhaseFailed, got %v", status.Phase)
+		}
+		if status.Reason != "SnapshotFailed" {
+			t.Errorf("expected Reason=SnapshotFailed, got %s", status.Reason)
+		}
+		if !strings.Contains(status.Message, "runsc checkpoint: unhandled syscall") {
+			t.Errorf("expected message to contain error details, got %s", status.Message)
+		}
+	})
+
+	t.Run("PodSnapshot_StorageReplicationFailed_FastFail", func(t *testing.T) {
+		trigger := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "podsnapshot.gke.io/v1",
+				"kind":       "PodSnapshotManualTrigger",
+				"metadata": map[string]interface{}{
+					"name":      triggerName,
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"snapshotCreated": map[string]interface{}{
+						"name": snapshotName,
+					},
+				},
+			},
+		}
+		snapshot := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "podsnapshot.gke.io/v1",
+				"kind":       "PodSnapshot",
+				"metadata": map[string]interface{}{
+					"name":      snapshotName,
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":    "StorageReplicated",
+							"status":  "False",
+							"reason":  "Failed",
+							"message": "GCS bucket permission denied",
+						},
+					},
+				},
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(trigger, snapshot).Build()
+		provider := NewGKEProvider(client, scheme)
+		job := &pmv1alpha1.PodMigrationJob{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+			Spec:       pmv1alpha1.PodMigrationJobSpec{TargetPodUID: "pod-uid-456"},
+		}
+		status, err := provider.CheckStatus(context.Background(), job, "test-pod")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status.Phase != PhaseFailed {
+			t.Fatalf("expected PhaseFailed, got %v", status.Phase)
+		}
+		if status.Reason != "SnapshotFailed" {
+			t.Errorf("expected Reason=SnapshotFailed, got %s", status.Reason)
 		}
 	})
 

--- a/controller/internal/snapshot/gke_provider_test.go
+++ b/controller/internal/snapshot/gke_provider_test.go
@@ -1,0 +1,137 @@
+package snapshot
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
+	"github.com/gke-labs/pod-migration/controller/internal/util"
+)
+
+func setupTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = pmv1alpha1.AddToScheme(s)
+	return s
+}
+
+func TestGKEProvider_EnsureTrigger(t *testing.T) {
+	scheme := setupTestScheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	provider := NewGKEProvider(client, scheme)
+
+	job := &pmv1alpha1.PodMigrationJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+			UID:       types.UID("job-uid-123"),
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			TargetPodUID: "pod-uid-456",
+		},
+	}
+
+	res, err := provider.EnsureTrigger(context.Background(), job, "test-pod")
+	if err != nil {
+		t.Fatalf("EnsureTrigger failed: %v", err)
+	}
+	if res.Requeue {
+		t.Errorf("expected requeue=false, got true")
+	}
+
+	// Verify trigger object was created
+	triggerName := util.FormatPSMTName("test-pod", "pod-uid-456")
+	trigger := &unstructured.Unstructured{}
+	trigger.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "podsnapshot.gke.io",
+		Version: "v1",
+		Kind:    "PodSnapshotManualTrigger",
+	})
+	if err := client.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: triggerName}, trigger); err != nil {
+		t.Fatalf("expected trigger to exist: %v", err)
+	}
+}
+
+func TestGKEProvider_CheckStatus(t *testing.T) {
+	scheme := setupTestScheme()
+	triggerName := util.FormatPSMTName("test-pod", "pod-uid-456")
+	snapshotName := "ps-snapshot-123"
+
+	t.Run("TriggerNotFound", func(t *testing.T) {
+		client := fake.NewClientBuilder().WithScheme(scheme).Build()
+		provider := NewGKEProvider(client, scheme)
+		job := &pmv1alpha1.PodMigrationJob{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+			Spec:       pmv1alpha1.PodMigrationJobSpec{TargetPodUID: "pod-uid-456"},
+		}
+		status, err := provider.CheckStatus(context.Background(), job, "test-pod")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status.Phase != PhaseInProgress {
+			t.Errorf("expected PhaseInProgress, got %v", status.Phase)
+		}
+	})
+
+	t.Run("SnapshotReady", func(t *testing.T) {
+		trigger := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "podsnapshot.gke.io/v1",
+				"kind":       "PodSnapshotManualTrigger",
+				"metadata": map[string]interface{}{
+					"name":      triggerName,
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"snapshotCreated": map[string]interface{}{
+						"name": snapshotName,
+					},
+				},
+			},
+		}
+		snapshot := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "podsnapshot.gke.io/v1",
+				"kind":       "PodSnapshot",
+				"metadata": map[string]interface{}{
+					"name":      snapshotName,
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":   "Ready",
+							"status": "True",
+							"reason": "AllSnapshotsAvailable",
+						},
+					},
+				},
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(trigger, snapshot).Build()
+		provider := NewGKEProvider(client, scheme)
+		job := &pmv1alpha1.PodMigrationJob{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+			Spec:       pmv1alpha1.PodMigrationJobSpec{TargetPodUID: "pod-uid-456"},
+		}
+		status, err := provider.CheckStatus(context.Background(), job, "test-pod")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status.Phase != PhaseReady {
+			t.Errorf("expected PhaseReady, got %v", status.Phase)
+		}
+		if status.SnapshotRef != snapshotName {
+			t.Errorf("expected snapshotRef=%s, got %s", snapshotName, status.SnapshotRef)
+		}
+	})
+}

--- a/controller/internal/snapshot/provider.go
+++ b/controller/internal/snapshot/provider.go
@@ -1,0 +1,38 @@
+package snapshot
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
+)
+
+// Phase represents the current state of a snapshot operation.
+type Phase string
+
+const (
+	PhaseInProgress Phase = "InProgress"
+	PhaseReady      Phase = "Ready"
+	PhaseFailed     Phase = "Failed"
+)
+
+// Status represents the observed result of a snapshot check.
+type Status struct {
+	Phase       Phase
+	SnapshotRef string
+	Reason      string
+	Message     string
+}
+
+// Provider abstracts the snapshot / checkpoint engine (e.g. GKE Pod Snapshots, CRIU, MicroVM).
+type Provider interface {
+	// EnsureTrigger creates or verifies the snapshot trigger for the origin pod.
+	EnsureTrigger(ctx context.Context, job *pmv1alpha1.PodMigrationJob, podName string) (ctrl.Result, error)
+
+	// CheckStatus checks whether the snapshot is ready, still in progress, or failed.
+	CheckStatus(ctx context.Context, job *pmv1alpha1.PodMigrationJob, podName string) (*Status, error)
+
+	// Cleanup deletes any trigger or temporary metadata created for the snapshot.
+	Cleanup(ctx context.Context, job *pmv1alpha1.PodMigrationJob, podName string) error
+}


### PR DESCRIPTION
### Summary
1. **Pluggable Snapshot Provider Abstraction**:
   - Extracted `internal/snapshot.Provider` interface (`EnsureTrigger`, `CheckStatus`, `Cleanup`) and `internal/snapshot.GKEProvider` to decouple the `PodMigrationJob` state machine from GKE-specific CR manipulation (`PodSnapshotManualTrigger` and `PodSnapshot`).
   - Paves the way for alternative runtime/snapshot backends (MicroVM, CRIU, etc.) with 0 controller state machine churn.

2. **Fast-Failure on Snapshot & Trigger Errors (Backlog 3.3 / ISSUE-3)**:
   - Previously, if GKE snapshotting failed (e.g. non-gVisor pod, missing snapshot policy, `runsc` checkpoint crash, or GCS upload error), the PMJ stayed in `Snapshotting` phase and wedged node drains for up to 10 minutes until `activeDeadlineSeconds` expired.
   - Now, `GKEProvider.CheckStatus` inspects:
     - `PSMT` conditions for `Triggered: False, Reason: Failed` $\to$ transitions PMJ immediately to `Failed` with `Reason: "SnapshotTriggerFailed"`.
     - `PodSnapshot` conditions for `Checkpoint / StorageReplicated / Ready: False, Reason: Failed` $\to$ transitions PMJ immediately to `Failed` with `Reason: "SnapshotFailed"`.
   - Allows instant fail-open cold eviction in $< 2$ seconds instead of wedging node drains for 10 minutes.

### Verification
- **Unit Tests**: Full test suites passing with race detector (`go test -v -race ./...`).
- **E2E Validation**: 21 / 21 workloads validated on GKE Standard cluster (`lpm-fresh-e2e`):
  `redis`, `dragonfly`, `vault`, `minio`, `nginx`, `haproxy`, `traefik`, `caddy`, `python`, `consul`, `mysql`, `mariadb`, `zookeeper`, `kafka`, `memcached`, `valkey`, `etcd`, `nats`, `postgres`, `node`, `go`.