### PR TITLE
feat: Workload Matching Precision — Batch Indexed Jobs, Generational UID Isolation & Single-Use Guard

### DIFF
--- a/controller/Makefile
+++ b/controller/Makefile
@@ -3,8 +3,9 @@
 
 IMG ?= controller:latest
 CONTROLLER_GEN ?= $(shell go env GOPATH)/bin/controller-gen
-SETUP_ENVTEST ?= $(shell go env GOPATH)/bin/setup-envtest
-.PHONY: help generate manifests fmt vet build run test install uninstall deploy undeploy docker-build docker-push
+ENVTEST_K8S_VERSION ?= 1.36.2
+SETUP_ENVTEST ?= $(shell which setup-envtest 2>/dev/null || echo $(shell go env GOPATH)/bin/setup-envtest)
+.PHONY: help generate manifests fmt vet build run envtest test install uninstall deploy undeploy docker-build docker-push
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -27,8 +28,14 @@ run: generate fmt vet manifests ## Run reconcilers against the current kubeconfi
 	# NB: webhooks need to run in-cluster with a serving cert; `make run` is for reconciler iteration.
 	go run ./cmd/main.go
 
-test: generate fmt vet manifests ## Run unit + envtest suite.
-	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use -p path 2>/dev/null)" \
+envtest: ## Download setup-envtest locally if necessary.
+	@if [ ! -x "$$(command -v $(SETUP_ENVTEST))" ] && [ ! -x "$(SETUP_ENVTEST)" ]; then \
+		echo "Installing setup-envtest..."; \
+		go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest; \
+	fi
+
+test: generate fmt vet manifests envtest ## Run unit + envtest suite.
+	KUBEBUILDER_ASSETS="$$($(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path 2>/dev/null || $(SETUP_ENVTEST) use -p path 2>/dev/null)" \
 		go test ./... -coverprofile cover.out
 
 install: manifests ## Install CRDs into the K8s cluster and wait for them to be ready.

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -3,6 +3,7 @@
 
 IMG ?= controller:latest
 CONTROLLER_GEN ?= $(shell go env GOPATH)/bin/controller-gen
+SETUP_ENVTEST ?= $(shell go env GOPATH)/bin/setup-envtest
 .PHONY: help generate manifests fmt vet build run test install uninstall deploy undeploy docker-build docker-push
 
 help:
@@ -27,7 +28,7 @@ run: generate fmt vet manifests ## Run reconcilers against the current kubeconfi
 	go run ./cmd/main.go
 
 test: generate fmt vet manifests ## Run unit + envtest suite.
-	KUBEBUILDER_ASSETS="$(shell setup-envtest use -p path)" \
+	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use -p path 2>/dev/null)" \
 		go test ./... -coverprofile cover.out
 
 install: manifests ## Install CRDs into the K8s cluster and wait for them to be ready.

--- a/controller/api/v1alpha1/podmigrationjob_types.go
+++ b/controller/api/v1alpha1/podmigrationjob_types.go
@@ -36,6 +36,15 @@ type PodMigrationJobStatus struct {
 	// +optional
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 
+	// Consumed indicates whether this migration snapshot has already been adopted by a replacement pod.
+	// Once true, subsequent pods will ignore this PMJ, preventing cross-generational stale state resurrection.
+	// +optional
+	Consumed bool `json:"consumed,omitempty"`
+
+	// RestoredPodUID records the UID of the replacement pod that adopted this migration snapshot.
+	// +optional
+	RestoredPodUID string `json:"restoredPodUID,omitempty"`
+
 	// Conditions represent the latest available observations of the job's current state.
 	// +optional
 	// +patchMergeKey=type

--- a/controller/cmd/main.go
+++ b/controller/cmd/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/controller/config/crd/bases/podmigration.gke.io_podmigrationjobs.yaml
+++ b/controller/config/crd/bases/podmigration.gke.io_podmigrationjobs.yaml
@@ -132,6 +132,11 @@ spec:
                   - type
                   type: object
                 type: array
+              consumed:
+                description: |-
+                  Consumed indicates whether this migration snapshot has already been adopted by a replacement pod.
+                  Once true, subsequent pods will ignore this PMJ, preventing cross-generational stale state resurrection.
+                type: boolean
               phase:
                 description: PodMigrationJobPhase defines the current state in the
                   lifecycle.
@@ -142,6 +147,10 @@ spec:
                 items:
                   type: string
                 type: array
+              restoredPodUID:
+                description: RestoredPodUID records the UID of the replacement pod
+                  that adopted this migration snapshot.
+                type: string
               snapshotRef:
                 description: SnapshotRef references the name of the created pod snapshot.
                 type: string

--- a/controller/internal/controller/crd_schema_test.go
+++ b/controller/internal/controller/crd_schema_test.go
@@ -1,0 +1,89 @@
+package controller
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
+)
+
+func TestCRDSchema_PodMigrationJob_StatusFields(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS not set; skipping envtest CRD schema test")
+	}
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{"../../config/crd/bases"},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("Failed to start envtest environment: %v", err)
+	}
+	defer func() {
+		if err := testEnv.Stop(); err != nil {
+			t.Errorf("Failed to stop envtest environment: %v", err)
+		}
+	}()
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add client-go scheme: %v", err)
+	}
+	if err := pmv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add pmv1alpha1 scheme: %v", err)
+	}
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("Failed to create k8s client: %v", err)
+	}
+
+	ctx := context.Background()
+	job := &pmv1alpha1.PodMigrationJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pmj-schema-drift",
+			Namespace: "default",
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef: corev1.LocalObjectReference{
+				Name: "test-workload-pod",
+			},
+			TargetPodUID: "target-uid-12345",
+		},
+	}
+
+	if err := k8sClient.Create(ctx, job); err != nil {
+		t.Fatalf("Failed to create PodMigrationJob: %v", err)
+	}
+
+	// Update status fields
+	job.Status.Consumed = true
+	job.Status.RestoredPodUID = "uid-123"
+	if err := k8sClient.Status().Update(ctx, job); err != nil {
+		t.Fatalf("Failed to update PodMigrationJob status: %v", err)
+	}
+
+	// Re-fetch the object from the API server and assert status fields
+	var fetched pmv1alpha1.PodMigrationJob
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: job.Namespace, Name: job.Name}, &fetched); err != nil {
+		t.Fatalf("Failed to fetch PodMigrationJob: %v", err)
+	}
+
+	if !fetched.Status.Consumed {
+		t.Errorf("Expected fetched.Status.Consumed == true, got false")
+	}
+	if fetched.Status.RestoredPodUID != "uid-123" {
+		t.Errorf("Expected fetched.Status.RestoredPodUID == %q, got %q", "uid-123", fetched.Status.RestoredPodUID)
+	}
+}

--- a/controller/internal/controller/pod_gate_controller.go
+++ b/controller/internal/controller/pod_gate_controller.go
@@ -117,6 +117,17 @@ func (r *PodGateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if phase == pmv1alpha1.PodMigrationJobPhaseSucceeded || phase == pmv1alpha1.PodMigrationJobPhaseFailed {
 		logger.Info("Assigned PMJ has completed, releasing scheduling gate", "pmj", correctedPMJ, "phase", phase)
 
+		if job.Status.Consumed && job.Status.RestoredPodUID != "" && job.Status.RestoredPodUID != string(pod.UID) {
+			logger.Info("Assigned PMJ was already consumed by a different pod, releasing gate with cold-start bypass",
+				"consumingPodUID", job.Status.RestoredPodUID, "currentPodUID", pod.UID)
+			if pod.Annotations == nil {
+				pod.Annotations = make(map[string]string)
+			}
+			pod.Annotations["podsnapshot.gke.io/ps-name"] = ""
+			r.removeGate(pod)
+			return ctrl.Result{}, r.Update(ctx, pod)
+		}
+
 		// If succeeded, inject GKE's native snapshot name annotation to force correct restore mapping
 		if phase == pmv1alpha1.PodMigrationJobPhaseSucceeded && job.Status.SnapshotRef != "" {
 			if pod.Annotations == nil {

--- a/controller/internal/controller/pod_gate_controller.go
+++ b/controller/internal/controller/pod_gate_controller.go
@@ -68,7 +68,7 @@ func (r *PodGateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// Resolve parent details to look up alternative PMJs in case of collision
-	parentName, parentKind, err := util.ResolveParentWorkload(ctx, r.Client, pod)
+	parentName, parentKind, parentUID, err := util.ResolveParentWorkload(ctx, r.Client, pod)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("Parent ReplicaSet not found (likely deleted), treating as bare pod")
@@ -79,7 +79,7 @@ func (r *PodGateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// Resolve any webhook assignment races
-	correctedPMJ, changed, err := util.ResolveCollision(ctx, r.Client, pod, assignedPMJ, parentName, parentKind)
+	correctedPMJ, changed, err := util.ResolveCollision(ctx, r.Client, pod, assignedPMJ, parentName, parentKind, parentUID)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -124,6 +124,16 @@ func (r *PodGateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 			pod.Annotations["podsnapshot.gke.io/ps-name"] = job.Status.SnapshotRef
 			logger.Info("Injected target snapshot ref to pod annotations", "snapshot", job.Status.SnapshotRef)
+		}
+
+		// Mark PMJ as consumed by this replacement pod to prevent stale resurrection
+		if !job.Status.Consumed {
+			job.Status.Consumed = true
+			job.Status.RestoredPodUID = string(pod.UID)
+			if updateErr := r.Status().Update(ctx, job); updateErr != nil {
+				logger.Error(updateErr, "Failed to mark PMJ as consumed")
+				return ctrl.Result{}, updateErr
+			}
 		}
 
 		r.removeGate(pod)

--- a/controller/internal/controller/pod_gate_controller.go
+++ b/controller/internal/controller/pod_gate_controller.go
@@ -123,6 +123,7 @@ func (r *PodGateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			if pod.Annotations == nil {
 				pod.Annotations = make(map[string]string)
 			}
+			delete(pod.Annotations, "pod-migration.gke.io/assigned-pmj")
 			pod.Annotations["podsnapshot.gke.io/ps-name"] = ""
 			r.removeGate(pod)
 			return ctrl.Result{}, r.Update(ctx, pod)

--- a/controller/internal/controller/pod_gate_controller_test.go
+++ b/controller/internal/controller/pod_gate_controller_test.go
@@ -776,4 +776,8 @@ func TestPodGateReconciler_Reconcile_AlreadyConsumedPMJ_ReleasesGateWithColdStar
 	if val, ok := updatedPod.Annotations["podsnapshot.gke.io/ps-name"]; !ok || val != "" {
 		t.Errorf("expected podsnapshot.gke.io/ps-name annotation to be %q, got %q (present: %t)", "", val, ok)
 	}
+
+	if val, ok := updatedPod.Annotations["pod-migration.gke.io/assigned-pmj"]; ok {
+		t.Errorf("expected pod-migration.gke.io/assigned-pmj annotation to be deleted, got %q", val)
+	}
 }

--- a/controller/internal/controller/pod_gate_controller_test.go
+++ b/controller/internal/controller/pod_gate_controller_test.go
@@ -777,4 +777,3 @@ func TestPodGateReconciler_Reconcile_AlreadyConsumedPMJ_ReleasesGateWithColdStar
 		t.Errorf("expected podsnapshot.gke.io/ps-name annotation to be %q, got %q (present: %t)", "", val, ok)
 	}
 }
-

--- a/controller/internal/controller/pod_gate_controller_test.go
+++ b/controller/internal/controller/pod_gate_controller_test.go
@@ -698,3 +698,83 @@ func TestPodGateReconciler_Reconcile_Collision_Deployment_AlternativePMJFound(t 
 		t.Errorf("expected loser pod to be reassigned to %q, got %q", altPmjName, assigned)
 	}
 }
+
+func TestPodGateReconciler_Reconcile_AlreadyConsumedPMJ_ReleasesGateWithColdStartBypass(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	namespace := "default"
+	pmjName := "pmj-consumed"
+
+	loserPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "pod-loser",
+			UID:       "uid-loser",
+			Annotations: map[string]string{
+				"pod-migration.gke.io/assigned-pmj": pmjName,
+			},
+		},
+		Spec: corev1.PodSpec{
+			SchedulingGates: []corev1.PodSchedulingGate{
+				{Name: "gke.io/pod-migration-gate"},
+			},
+		},
+	}
+
+	pmj := &pmv1alpha1.PodMigrationJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      pmjName,
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef: corev1.LocalObjectReference{Name: "pod-orig"},
+		},
+		Status: pmv1alpha1.PodMigrationJobStatus{
+			Phase:          pmv1alpha1.PodMigrationJobPhaseSucceeded,
+			SnapshotRef:    "snapshot-ref",
+			Consumed:       true,
+			RestoredPodUID: "uid-winner",
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+		WithObjects(loserPod, pmj).
+		Build()
+
+	r := &PodGateReconciler{
+		Client: cl,
+		Scheme: scheme,
+	}
+
+	ctx := context.Background()
+	_, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      "pod-loser",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updatedPod := &corev1.Pod{}
+	err = cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "pod-loser"}, updatedPod)
+	if err != nil {
+		t.Fatalf("failed to fetch updated pod: %v", err)
+	}
+
+	for _, gate := range updatedPod.Spec.SchedulingGates {
+		if gate.Name == "gke.io/pod-migration-gate" {
+			t.Error("expected scheduling gate to be removed")
+		}
+	}
+
+	if val, ok := updatedPod.Annotations["podsnapshot.gke.io/ps-name"]; !ok || val != "" {
+		t.Errorf("expected podsnapshot.gke.io/ps-name annotation to be %q, got %q (present: %t)", "", val, ok)
+	}
+}
+

--- a/controller/internal/controller/pod_gate_controller_test.go
+++ b/controller/internal/controller/pod_gate_controller_test.go
@@ -190,7 +190,11 @@ func TestPodGateReconciler_Reconcile(t *testing.T) {
 				initObjs = append(initObjs, tt.pmj)
 			}
 
-			cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjs...).Build()
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+				WithRuntimeObjects(initObjs...).
+				Build()
 			r := &PodGateReconciler{
 				Client: cl,
 				Scheme: scheme,

--- a/controller/internal/util/assignment.go
+++ b/controller/internal/util/assignment.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -15,11 +16,12 @@ import (
 )
 
 const (
-	LabelParentName       = "pod-migration.gke.io/parent-name"
-	LabelParentKind       = "pod-migration.gke.io/parent-kind"
-	LabelPodTemplateHash  = "pod-migration.gke.io/pod-template-hash"
-	LabelOriginPodName    = "pod-migration.gke.io/origin-pod-name"
-	AnnotationAssignedPMJ = "pod-migration.gke.io/assigned-pmj"
+	LabelParentName         = "pod-migration.gke.io/parent-name"
+	LabelParentKind         = "pod-migration.gke.io/parent-kind"
+	LabelPodTemplateHash    = "pod-migration.gke.io/pod-template-hash"
+	LabelJobCompletionIndex = batchv1.JobCompletionIndexAnnotation
+	LabelOriginPodName      = "pod-migration.gke.io/origin-pod-name"
+	AnnotationAssignedPMJ   = "pod-migration.gke.io/assigned-pmj"
 )
 
 // ResolveParentWorkload finds the parent owner details (ReplicaSet -> Deployment, Job, or StatefulSet).
@@ -63,7 +65,7 @@ func FormatPSMTName(podName, uid string) string {
 }
 
 // FindUnassignedActivePMJ searches for an active PMJ under the parent that hasn't been assigned to a pod yet.
-func FindUnassignedActivePMJ(ctx context.Context, c client.Client, namespace, podName, parentName, parentKind, podTemplateHash string) (string, error) {
+func FindUnassignedActivePMJ(ctx context.Context, c client.Client, namespace, podName, parentName, parentKind, podTemplateHash, jobCompletionIndex string) (string, error) {
 	// Scan pods to find which PMJs are already assigned
 	assignedPMJs := make(map[string]bool)
 	podList := &corev1.PodList{}
@@ -101,6 +103,11 @@ func FindUnassignedActivePMJ(ctx context.Context, c client.Client, namespace, po
 
 			// For Deployments, enforce pod-template-hash revision match
 			if parentKind == "Deployment" && job.Labels[LabelPodTemplateHash] != podTemplateHash {
+				continue
+			}
+
+			// For Indexed Jobs, enforce job-completion-index ordinal match
+			if parentKind == "Job" && jobCompletionIndex != "" && job.Labels[LabelJobCompletionIndex] != jobCompletionIndex {
 				continue
 			}
 
@@ -171,12 +178,14 @@ func ResolveCollision(ctx context.Context, c client.Client, pod *corev1.Pod, ass
 	}
 
 	var podTemplateHash string
+	var jobCompletionIndex string
 	if pod.Labels != nil {
 		podTemplateHash = pod.Labels[appsv1.DefaultDeploymentUniqueLabelKey]
+		jobCompletionIndex = pod.Labels[LabelJobCompletionIndex]
 	}
 
 	// We are the loser! Try to find an alternative active PMJ
-	altPMJ, err := FindUnassignedActivePMJ(ctx, c, pod.Namespace, pod.Name, parentName, parentKind, podTemplateHash)
+	altPMJ, err := FindUnassignedActivePMJ(ctx, c, pod.Namespace, pod.Name, parentName, parentKind, podTemplateHash, jobCompletionIndex)
 	if err != nil {
 		return "", false, err
 	}

--- a/controller/internal/util/assignment.go
+++ b/controller/internal/util/assignment.go
@@ -18,6 +18,7 @@ import (
 const (
 	LabelParentName         = "pod-migration.gke.io/parent-name"
 	LabelParentKind         = "pod-migration.gke.io/parent-kind"
+	LabelParentUID          = "pod-migration.gke.io/parent-uid"
 	LabelPodTemplateHash    = "pod-migration.gke.io/pod-template-hash"
 	LabelJobCompletionIndex = batchv1.JobCompletionIndexAnnotation
 	LabelOriginPodName      = "pod-migration.gke.io/origin-pod-name"
@@ -25,7 +26,7 @@ const (
 )
 
 // ResolveParentWorkload finds the parent owner details (ReplicaSet -> Deployment, Job, or StatefulSet).
-func ResolveParentWorkload(ctx context.Context, c client.Client, pod *corev1.Pod) (string, string, error) {
+func ResolveParentWorkload(ctx context.Context, c client.Client, pod *corev1.Pod) (string, string, string, error) {
 	for _, ref := range pod.OwnerReferences {
 		if ref.Kind == "ReplicaSet" {
 			rs := &appsv1.ReplicaSet{}
@@ -33,17 +34,17 @@ func ResolveParentWorkload(ctx context.Context, c client.Client, pod *corev1.Pod
 			if err == nil {
 				for _, rsRef := range rs.OwnerReferences {
 					if rsRef.Kind == "Deployment" {
-						return rsRef.Name, "Deployment", nil
+						return rsRef.Name, "Deployment", string(rsRef.UID), nil
 					}
 				}
 			} else {
-				return "", "", err
+				return "", "", "", err
 			}
 		} else if ref.Kind == "Job" || ref.Kind == "StatefulSet" {
-			return ref.Name, ref.Kind, nil
+			return ref.Name, ref.Kind, string(ref.UID), nil
 		}
 	}
-	return "", "", nil
+	return "", "", "", nil
 }
 
 // ShortUID returns the first 8 characters of a UID, or the full UID if shorter.
@@ -65,7 +66,7 @@ func FormatPSMTName(podName, uid string) string {
 }
 
 // FindUnassignedActivePMJ searches for an active PMJ under the parent that hasn't been assigned to a pod yet.
-func FindUnassignedActivePMJ(ctx context.Context, c client.Client, namespace, podName, parentName, parentKind, podTemplateHash, jobCompletionIndex string) (string, error) {
+func FindUnassignedActivePMJ(ctx context.Context, c client.Client, namespace, podName, parentName, parentKind, parentUID, podTemplateHash, jobCompletionIndex string) (string, error) {
 	// Scan pods to find which PMJs are already assigned
 	assignedPMJs := make(map[string]bool)
 	podList := &corev1.PodList{}
@@ -90,6 +91,11 @@ func FindUnassignedActivePMJ(ctx context.Context, c client.Client, namespace, po
 
 	// Pick the first active PMJ that is not yet assigned
 	for _, job := range jobList.Items {
+		// Skip already consumed PMJs
+		if job.Status.Consumed {
+			continue
+		}
+
 		if parentName == "" {
 			// Bare Pod: match by origin pod name and absence of parent label
 			if job.Spec.PodRef.Name != podName || job.Labels[LabelParentName] != "" {
@@ -98,6 +104,11 @@ func FindUnassignedActivePMJ(ctx context.Context, c client.Client, namespace, po
 		} else {
 			if job.Labels[LabelParentName] != parentName ||
 				job.Labels[LabelParentKind] != parentKind {
+				continue
+			}
+
+			// Enforce parent workload UID equality to prevent cross-generation resurrection
+			if parentUID != "" && job.Labels[LabelParentUID] != "" && job.Labels[LabelParentUID] != parentUID {
 				continue
 			}
 
@@ -132,7 +143,7 @@ func FindUnassignedActivePMJ(ctx context.Context, c client.Client, namespace, po
 
 // ResolveCollision deterministically resolves PMJ assignment races.
 // Returns: (correctedPMJ, changed, error)
-func ResolveCollision(ctx context.Context, c client.Client, pod *corev1.Pod, assignedPMJ, parentName, parentKind string) (string, bool, error) {
+func ResolveCollision(ctx context.Context, c client.Client, pod *corev1.Pod, assignedPMJ, parentName, parentKind, parentUID string) (string, bool, error) {
 	// Fetch the assigned PMJ to check targetPodUID
 	job := &pmv1alpha1.PodMigrationJob{}
 	if err := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: assignedPMJ}, job); err != nil {
@@ -185,7 +196,7 @@ func ResolveCollision(ctx context.Context, c client.Client, pod *corev1.Pod, ass
 	}
 
 	// We are the loser! Try to find an alternative active PMJ
-	altPMJ, err := FindUnassignedActivePMJ(ctx, c, pod.Namespace, pod.Name, parentName, parentKind, podTemplateHash, jobCompletionIndex)
+	altPMJ, err := FindUnassignedActivePMJ(ctx, c, pod.Namespace, pod.Name, parentName, parentKind, parentUID, podTemplateHash, jobCompletionIndex)
 	if err != nil {
 		return "", false, err
 	}

--- a/controller/internal/util/assignment_test.go
+++ b/controller/internal/util/assignment_test.go
@@ -82,7 +82,7 @@ func TestFindUnassignedActivePMJ_BarePod(t *testing.T) {
 			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.existing...).Build()
 			ctx := context.Background()
 
-			result, err := FindUnassignedActivePMJ(ctx, c, "default", tc.podName, "", "", "", "")
+			result, err := FindUnassignedActivePMJ(ctx, c, "default", tc.podName, "", "", "", "", "")
 			if (err != nil) != tc.expectErr {
 				t.Fatalf("expected error: %v, got: %v", tc.expectErr, err)
 			}
@@ -259,7 +259,7 @@ func TestFindUnassignedActivePMJ_DeploymentRevisionIsolation(t *testing.T) {
 			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.existing...).Build()
 			ctx := context.Background()
 
-			result, err := FindUnassignedActivePMJ(ctx, c, "default", tc.podName, tc.parentName, tc.parentKind, tc.podTemplateHash, "")
+			result, err := FindUnassignedActivePMJ(ctx, c, "default", tc.podName, tc.parentName, tc.parentKind, "", tc.podTemplateHash, "")
 			if (err != nil) != tc.expectErr {
 				t.Fatalf("expected error: %v, got: %v", tc.expectErr, err)
 			}
@@ -433,7 +433,211 @@ func TestFindUnassignedActivePMJ_BatchIndexedJobs(t *testing.T) {
 			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.existing...).Build()
 			ctx := context.Background()
 
-			result, err := FindUnassignedActivePMJ(ctx, c, "default", tc.podName, tc.parentName, tc.parentKind, "", tc.jobCompletionIndex)
+			result, err := FindUnassignedActivePMJ(ctx, c, "default", tc.podName, tc.parentName, tc.parentKind, "", "", tc.jobCompletionIndex)
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("expected error: %v, got: %v", tc.expectErr, err)
+			}
+			if result != tc.expected {
+				t.Errorf("expected: %q, got: %q", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestFindUnassignedActivePMJ_GenerationalWorkloadIsolation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name       string
+		podName    string
+		parentName string
+		parentKind string
+		parentUID  string
+		existing   []runtime.Object
+		expected   string
+		expectErr  bool
+	}{
+		{
+			name:       "StatefulSet pod matches PMJ with identical parent UID (same generation)",
+			podName:    "redis-0",
+			parentName: "redis",
+			parentKind: "StatefulSet",
+			parentUID:  "uid-generation-1",
+			existing: []runtime.Object{
+				&pmv1alpha1.PodMigrationJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pmj-redis-0-gen1",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelParentName: "redis",
+							LabelParentKind: "StatefulSet",
+							LabelParentUID:  "uid-generation-1",
+						},
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{Name: "redis-0"},
+					},
+					Status: pmv1alpha1.PodMigrationJobStatus{
+						Phase: pmv1alpha1.PodMigrationJobPhaseSucceeded,
+					},
+				},
+			},
+			expected: "pmj-redis-0-gen1",
+		},
+		{
+			name:       "Redeployed StatefulSet pod with new parent UID does NOT match PMJ from old deleted generation",
+			podName:    "redis-0",
+			parentName: "redis",
+			parentKind: "StatefulSet",
+			parentUID:  "uid-generation-2", // New generation
+			existing: []runtime.Object{
+				&pmv1alpha1.PodMigrationJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pmj-redis-0-gen1",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelParentName: "redis",
+							LabelParentKind: "StatefulSet",
+							LabelParentUID:  "uid-generation-1", // Old generation
+						},
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{Name: "redis-0"},
+					},
+					Status: pmv1alpha1.PodMigrationJobStatus{
+						Phase: pmv1alpha1.PodMigrationJobPhaseSucceeded,
+					},
+				},
+			},
+			expected: "", // Stale state resurrection prevented!
+		},
+		{
+			name:       "Deployment pod with new parent UID does NOT match PMJ from old deleted generation",
+			podName:    "web-xyz",
+			parentName: "web-deploy",
+			parentKind: "Deployment",
+			parentUID:  "uid-deploy-gen2",
+			existing: []runtime.Object{
+				&pmv1alpha1.PodMigrationJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pmj-web-gen1",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelParentName: "web-deploy",
+							LabelParentKind: "Deployment",
+							LabelParentUID:  "uid-deploy-gen1",
+						},
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{Name: "web-abc"},
+					},
+					Status: pmv1alpha1.PodMigrationJobStatus{
+						Phase: pmv1alpha1.PodMigrationJobPhaseSucceeded,
+					},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.existing...).Build()
+			ctx := context.Background()
+
+			result, err := FindUnassignedActivePMJ(ctx, c, "default", tc.podName, tc.parentName, tc.parentKind, tc.parentUID, "", "")
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("expected error: %v, got: %v", tc.expectErr, err)
+			}
+			if result != tc.expected {
+				t.Errorf("expected: %q, got: %q", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestFindUnassignedActivePMJ_SingleUseConsumedGuard(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name       string
+		podName    string
+		parentName string
+		parentKind string
+		parentUID  string
+		existing   []runtime.Object
+		expected   string
+		expectErr  bool
+	}{
+		{
+			name:       "Unconsumed Succeeded PMJ is eligible for adoption",
+			podName:    "redis-0",
+			parentName: "redis",
+			parentKind: "StatefulSet",
+			parentUID:  "uid-123",
+			existing: []runtime.Object{
+				&pmv1alpha1.PodMigrationJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pmj-redis-0",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelParentName: "redis",
+							LabelParentKind: "StatefulSet",
+							LabelParentUID:  "uid-123",
+						},
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{Name: "redis-0"},
+					},
+					Status: pmv1alpha1.PodMigrationJobStatus{
+						Phase:    pmv1alpha1.PodMigrationJobPhaseSucceeded,
+						Consumed: false,
+					},
+				},
+			},
+			expected: "pmj-redis-0",
+		},
+		{
+			name:       "Already consumed PMJ is NOT eligible for adoption (crash/re-spawn guard)",
+			podName:    "redis-0",
+			parentName: "redis",
+			parentKind: "StatefulSet",
+			parentUID:  "uid-123",
+			existing: []runtime.Object{
+				&pmv1alpha1.PodMigrationJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pmj-redis-0",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelParentName: "redis",
+							LabelParentKind: "StatefulSet",
+							LabelParentUID:  "uid-123",
+						},
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{Name: "redis-0"},
+					},
+					Status: pmv1alpha1.PodMigrationJobStatus{
+						Phase:          pmv1alpha1.PodMigrationJobPhaseSucceeded,
+						Consumed:       true, // Already consumed by prior replacement pod
+						RestoredPodUID: "prior-pod-uid",
+					},
+				},
+			},
+			expected: "", // Single-use consumption guard prevents double restore!
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.existing...).Build()
+			ctx := context.Background()
+
+			result, err := FindUnassignedActivePMJ(ctx, c, "default", tc.podName, tc.parentName, tc.parentKind, tc.parentUID, "", "")
 			if (err != nil) != tc.expectErr {
 				t.Fatalf("expected error: %v, got: %v", tc.expectErr, err)
 			}

--- a/controller/internal/util/assignment_test.go
+++ b/controller/internal/util/assignment_test.go
@@ -82,7 +82,7 @@ func TestFindUnassignedActivePMJ_BarePod(t *testing.T) {
 			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.existing...).Build()
 			ctx := context.Background()
 
-			result, err := FindUnassignedActivePMJ(ctx, c, "default", tc.podName, "", "", "")
+			result, err := FindUnassignedActivePMJ(ctx, c, "default", tc.podName, "", "", "", "")
 			if (err != nil) != tc.expectErr {
 				t.Fatalf("expected error: %v, got: %v", tc.expectErr, err)
 			}
@@ -259,7 +259,181 @@ func TestFindUnassignedActivePMJ_DeploymentRevisionIsolation(t *testing.T) {
 			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.existing...).Build()
 			ctx := context.Background()
 
-			result, err := FindUnassignedActivePMJ(ctx, c, "default", tc.podName, tc.parentName, tc.parentKind, tc.podTemplateHash)
+			result, err := FindUnassignedActivePMJ(ctx, c, "default", tc.podName, tc.parentName, tc.parentKind, tc.podTemplateHash, "")
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("expected error: %v, got: %v", tc.expectErr, err)
+			}
+			if result != tc.expected {
+				t.Errorf("expected: %q, got: %q", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestFindUnassignedActivePMJ_BatchIndexedJobs(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name               string
+		podName            string
+		parentName         string
+		parentKind         string
+		jobCompletionIndex string
+		existing           []runtime.Object
+		expected           string
+		expectErr          bool
+	}{
+		{
+			name:               "Indexed Job pod index 0 matches PMJ for index 0",
+			podName:            "indexed-job-0-abc",
+			parentName:         "my-indexed-job",
+			parentKind:         "Job",
+			jobCompletionIndex: "0",
+			existing: []runtime.Object{
+				&pmv1alpha1.PodMigrationJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pmj-job-idx0",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelParentName:         "my-indexed-job",
+							LabelParentKind:         "Job",
+							LabelJobCompletionIndex: "0",
+						},
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{Name: "indexed-job-0-orig"},
+					},
+					Status: pmv1alpha1.PodMigrationJobStatus{
+						Phase: pmv1alpha1.PodMigrationJobPhaseSnapshotting,
+					},
+				},
+				&pmv1alpha1.PodMigrationJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pmj-job-idx1",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelParentName:         "my-indexed-job",
+							LabelParentKind:         "Job",
+							LabelJobCompletionIndex: "1",
+						},
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{Name: "indexed-job-1-orig"},
+					},
+					Status: pmv1alpha1.PodMigrationJobStatus{
+						Phase: pmv1alpha1.PodMigrationJobPhaseSnapshotting,
+					},
+				},
+			},
+			expected: "pmj-job-idx0",
+		},
+		{
+			name:               "Indexed Job pod index 1 matches PMJ for index 1",
+			podName:            "indexed-job-1-xyz",
+			parentName:         "my-indexed-job",
+			parentKind:         "Job",
+			jobCompletionIndex: "1",
+			existing: []runtime.Object{
+				&pmv1alpha1.PodMigrationJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pmj-job-idx0",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelParentName:         "my-indexed-job",
+							LabelParentKind:         "Job",
+							LabelJobCompletionIndex: "0",
+						},
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{Name: "indexed-job-0-orig"},
+					},
+					Status: pmv1alpha1.PodMigrationJobStatus{
+						Phase: pmv1alpha1.PodMigrationJobPhaseSnapshotting,
+					},
+				},
+				&pmv1alpha1.PodMigrationJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pmj-job-idx1",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelParentName:         "my-indexed-job",
+							LabelParentKind:         "Job",
+							LabelJobCompletionIndex: "1",
+						},
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{Name: "indexed-job-1-orig"},
+					},
+					Status: pmv1alpha1.PodMigrationJobStatus{
+						Phase: pmv1alpha1.PodMigrationJobPhaseSnapshotting,
+					},
+				},
+			},
+			expected: "pmj-job-idx1",
+		},
+		{
+			name:               "Indexed Job pod index 2 does NOT match existing PMJs for index 0 or 1",
+			podName:            "indexed-job-2-new",
+			parentName:         "my-indexed-job",
+			parentKind:         "Job",
+			jobCompletionIndex: "2",
+			existing: []runtime.Object{
+				&pmv1alpha1.PodMigrationJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pmj-job-idx0",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelParentName:         "my-indexed-job",
+							LabelParentKind:         "Job",
+							LabelJobCompletionIndex: "0",
+						},
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{Name: "indexed-job-0-orig"},
+					},
+					Status: pmv1alpha1.PodMigrationJobStatus{
+						Phase: pmv1alpha1.PodMigrationJobPhaseSnapshotting,
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:               "Non-indexed parallel Job matches active PMJ without index constraint",
+			podName:            "parallel-job-pod-2",
+			parentName:         "my-parallel-job",
+			parentKind:         "Job",
+			jobCompletionIndex: "",
+			existing: []runtime.Object{
+				&pmv1alpha1.PodMigrationJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pmj-parallel-job-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelParentName: "my-parallel-job",
+							LabelParentKind: "Job",
+						},
+					},
+					Spec: pmv1alpha1.PodMigrationJobSpec{
+						PodRef: corev1.LocalObjectReference{Name: "parallel-job-pod-1"},
+					},
+					Status: pmv1alpha1.PodMigrationJobStatus{
+						Phase: pmv1alpha1.PodMigrationJobPhaseSnapshotting,
+					},
+				},
+			},
+			expected: "pmj-parallel-job-1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.existing...).Build()
+			ctx := context.Background()
+
+			result, err := FindUnassignedActivePMJ(ctx, c, "default", tc.podName, tc.parentName, tc.parentKind, "", tc.jobCompletionIndex)
 			if (err != nil) != tc.expectErr {
 				t.Fatalf("expected error: %v, got: %v", tc.expectErr, err)
 			}

--- a/controller/internal/webhook/eviction_webhook.go
+++ b/controller/internal/webhook/eviction_webhook.go
@@ -143,6 +143,9 @@ func (a *EvictionGate) Handle(ctx context.Context, req admission.Request) admiss
 	if hash, ok := pod.Labels[appsv1.DefaultDeploymentUniqueLabelKey]; ok && hash != "" {
 		jobLabels[util.LabelPodTemplateHash] = hash
 	}
+	if idx, ok := pod.Labels[util.LabelJobCompletionIndex]; ok && idx != "" {
+		jobLabels[util.LabelJobCompletionIndex] = idx
+	}
 
 	// 1. Find matching PodSnapshotPolicy (manual + stop)
 	matchingPSP, err := findLatestReadyManualStopPSP(ctx, a.Client, req.Namespace, pod.Labels)

--- a/controller/internal/webhook/eviction_webhook.go
+++ b/controller/internal/webhook/eviction_webhook.go
@@ -103,42 +103,19 @@ func (a *EvictionGate) Handle(ctx context.Context, req admission.Request) admiss
 	}
 
 	// Resolve parent owner details
-	parentName := ""
-	parentKind := ""
-	for _, ref := range pod.OwnerReferences {
-		if ref.Kind == "ReplicaSet" {
-			rs := &appsv1.ReplicaSet{}
-			err := a.Client.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: ref.Name}, rs)
-			if err == nil {
-				for _, rsRef := range rs.OwnerReferences {
-					if rsRef.Kind == "Deployment" {
-						parentName = rsRef.Name
-						parentKind = "Deployment"
-						break
-					}
-				}
-			} else if !apierrors.IsNotFound(err) {
-				logger.Error(err, "Failed to get ReplicaSet parent")
-				return denied429("transient error resolving parent workload, retrying")
-			}
-			if parentName != "" {
-				break
-			}
-		} else if ref.Kind == "Job" {
-			parentName = ref.Name
-			parentKind = "Job"
-			break
-		} else if ref.Kind == "StatefulSet" {
-			parentName = ref.Name
-			parentKind = "StatefulSet"
-			break
-		}
+	parentName, parentKind, parentUID, err := util.ResolveParentWorkload(ctx, a.Client, pod)
+	if err != nil && !apierrors.IsNotFound(err) {
+		logger.Error(err, "Failed to resolve parent workload")
+		return denied429("transient error resolving parent workload, retrying")
 	}
 
 	jobLabels := map[string]string{}
 	if parentName != "" {
 		jobLabels[util.LabelParentName] = parentName
 		jobLabels[util.LabelParentKind] = parentKind
+		if parentUID != "" {
+			jobLabels[util.LabelParentUID] = parentUID
+		}
 	}
 	if hash, ok := pod.Labels[appsv1.DefaultDeploymentUniqueLabelKey]; ok && hash != "" {
 		jobLabels[util.LabelPodTemplateHash] = hash

--- a/controller/internal/webhook/eviction_webhook_test.go
+++ b/controller/internal/webhook/eviction_webhook_test.go
@@ -179,7 +179,7 @@ func TestEvictionGate(t *testing.T) {
 					Name:      "indexed-job-pod-0",
 					UID:       "pod-uid-job-0",
 					Labels: map[string]string{
-						"pod-migration.gke.io/enabled":           "true",
+						"pod-migration.gke.io/enabled":             "true",
 						"batch.kubernetes.io/job-completion-index": "0",
 					},
 					OwnerReferences: []metav1.OwnerReference{

--- a/controller/internal/webhook/eviction_webhook_test.go
+++ b/controller/internal/webhook/eviction_webhook_test.go
@@ -172,6 +172,44 @@ func TestEvictionGate(t *testing.T) {
 			},
 		},
 		{
+			name: "Trigger migration on Indexed Job pod sets parent labels and job completion index",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "indexed-job-pod-0",
+					UID:       "pod-uid-job-0",
+					Labels: map[string]string{
+						"pod-migration.gke.io/enabled":           "true",
+						"batch.kubernetes.io/job-completion-index": "0",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "batch/v1",
+							Kind:       "Job",
+							Name:       "my-indexed-job",
+							UID:        "job-uid-999",
+						},
+					},
+				},
+				Spec: corev1.PodSpec{
+					RuntimeClassName: &gvisorRuntime,
+				},
+			},
+			initObjects: []client.Object{
+				createPSP("psp-test-manual", "manual", "stop"),
+			},
+			subResource:        "eviction",
+			expectedAllowed:    false,
+			expectedStatusCode: 429,
+			expectedMessage:    "migration job spawned",
+			verifyPMJCreated:   true,
+			expectedLabels: map[string]string{
+				util.LabelParentName:         "my-indexed-job",
+				util.LabelParentKind:         "Job",
+				util.LabelJobCompletionIndex: "0",
+			},
+		},
+		{
 			name: "Bypass migration when no policy found (No Policy)",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/controller/internal/webhook/replacement_webhook.go
+++ b/controller/internal/webhook/replacement_webhook.go
@@ -47,12 +47,14 @@ func (a *PodGateInjector) Handle(ctx context.Context, req admission.Request) adm
 	}
 
 	var podTemplateHash string
+	var jobCompletionIndex string
 	if pod.Labels != nil {
 		podTemplateHash = pod.Labels[appsv1.DefaultDeploymentUniqueLabelKey]
+		jobCompletionIndex = pod.Labels[util.LabelJobCompletionIndex]
 	}
 
 	// Find active unassigned PMJ
-	assignedPMJ, err := util.FindUnassignedActivePMJ(ctx, a.Client, req.Namespace, pod.Name, parentName, parentKind, podTemplateHash)
+	assignedPMJ, err := util.FindUnassignedActivePMJ(ctx, a.Client, req.Namespace, pod.Name, parentName, parentKind, podTemplateHash, jobCompletionIndex)
 	if err != nil {
 		logger.Error(err, "Failed to check unassigned active PMJs")
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/controller/internal/webhook/replacement_webhook.go
+++ b/controller/internal/webhook/replacement_webhook.go
@@ -7,6 +7,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -40,10 +41,14 @@ func (a *PodGateInjector) Handle(ctx context.Context, req admission.Request) adm
 	}
 
 	// Resolve parent owner details
-	parentName, parentKind, err := util.ResolveParentWorkload(ctx, a.Client, pod)
+	parentName, parentKind, parentUID, err := util.ResolveParentWorkload(ctx, a.Client, pod)
 	if err != nil {
-		logger.Error(err, "Failed to resolve parent workload")
-		return admission.Errored(http.StatusInternalServerError, err)
+		if apierrors.IsNotFound(err) {
+			logger.Info("Parent ReplicaSet not found (likely deleted), treating as bare pod")
+		} else {
+			logger.Error(err, "Failed to resolve parent workload")
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
 	}
 
 	var podTemplateHash string
@@ -54,7 +59,7 @@ func (a *PodGateInjector) Handle(ctx context.Context, req admission.Request) adm
 	}
 
 	// Find active unassigned PMJ
-	assignedPMJ, err := util.FindUnassignedActivePMJ(ctx, a.Client, req.Namespace, pod.Name, parentName, parentKind, podTemplateHash, jobCompletionIndex)
+	assignedPMJ, err := util.FindUnassignedActivePMJ(ctx, a.Client, req.Namespace, pod.Name, parentName, parentKind, parentUID, podTemplateHash, jobCompletionIndex)
 	if err != nil {
 		logger.Error(err, "Failed to check unassigned active PMJs")
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/controller/internal/webhook/replacement_webhook_test.go
+++ b/controller/internal/webhook/replacement_webhook_test.go
@@ -382,7 +382,7 @@ func TestPodGateInjector(t *testing.T) {
 					Namespace: "default",
 					Name:      "test-job-0-abc",
 					Labels: map[string]string{
-						"pod-migration.gke.io/enabled":           "true",
+						"pod-migration.gke.io/enabled":             "true",
 						"batch.kubernetes.io/job-completion-index": "0",
 					},
 					OwnerReferences: []metav1.OwnerReference{
@@ -422,7 +422,7 @@ func TestPodGateInjector(t *testing.T) {
 					Namespace: "default",
 					Name:      "test-job-2-xyz",
 					Labels: map[string]string{
-						"pod-migration.gke.io/enabled":           "true",
+						"pod-migration.gke.io/enabled":             "true",
 						"batch.kubernetes.io/job-completion-index": "2",
 					},
 					OwnerReferences: []metav1.OwnerReference{

--- a/controller/internal/webhook/replacement_webhook_test.go
+++ b/controller/internal/webhook/replacement_webhook_test.go
@@ -375,6 +375,86 @@ func TestPodGateInjector(t *testing.T) {
 			expectGate:      true,
 			expectBypass:    false,
 		},
+		{
+			name: "Indexed Job pod index 0 matches PMJ for index 0 (gate injected)",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-job-0-abc",
+					Labels: map[string]string{
+						"pod-migration.gke.io/enabled":           "true",
+						"batch.kubernetes.io/job-completion-index": "0",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "batch/v1",
+							Kind:       "Job",
+							Name:       "test-indexed-job",
+							UID:        "job-uid-1",
+						},
+					},
+				},
+			},
+			initObjs: []runtime.Object{
+				&pmv1alpha1.PodMigrationJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "pmj-job-0",
+						Labels: map[string]string{
+							"pod-migration.gke.io/parent-name":         "test-indexed-job",
+							"pod-migration.gke.io/parent-kind":         "Job",
+							"batch.kubernetes.io/job-completion-index": "0",
+						},
+					},
+					Status: pmv1alpha1.PodMigrationJobStatus{
+						Phase: pmv1alpha1.PodMigrationJobPhasePending,
+					},
+				},
+			},
+			expectedAllowed: true,
+			expectGate:      true,
+			expectBypass:    false,
+		},
+		{
+			name: "Indexed Job pod index 2 with only index 0 PMJ bypasses gate (scale-up pod)",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-job-2-xyz",
+					Labels: map[string]string{
+						"pod-migration.gke.io/enabled":           "true",
+						"batch.kubernetes.io/job-completion-index": "2",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "batch/v1",
+							Kind:       "Job",
+							Name:       "test-indexed-job",
+							UID:        "job-uid-1",
+						},
+					},
+				},
+			},
+			initObjs: []runtime.Object{
+				&pmv1alpha1.PodMigrationJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "pmj-job-0",
+						Labels: map[string]string{
+							"pod-migration.gke.io/parent-name":         "test-indexed-job",
+							"pod-migration.gke.io/parent-kind":         "Job",
+							"batch.kubernetes.io/job-completion-index": "0",
+						},
+					},
+					Status: pmv1alpha1.PodMigrationJobStatus{
+						Phase: pmv1alpha1.PodMigrationJobPhasePending,
+					},
+				},
+			},
+			expectedAllowed: true,
+			expectGate:      false,
+			expectBypass:    true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
This PR hardens workload assignment precision and eliminates cross-generation stale state resurrection and double restores across all Kubernetes workload types (Batch Jobs, StatefulSets, Deployments).

### What's Changed
1. **Batch Indexed Jobs Support (Backlog 1.2 / ISSUE-4)**:
   - Propagated standard `batch.kubernetes.io/job-completion-index` to PMJ metadata (`LabelJobCompletionIndex`).
   - Enforced ordinal completion index equality in `FindUnassignedActivePMJ` and `ResolveCollision` so concurrent multi-worker drains assign snapshots strictly to their matching completion index.
2. **Generational Workload UID Isolation (Backlog 1.4 / ISSUE-6 / R2-2)**:
   - Propagated parent workload UID (`pod-migration.gke.io/parent-uid`) via `util.ResolveParentWorkload` to PMJ labels at eviction intercept time.
   - Enforced `job.Labels[LabelParentUID] == parentUID` in `FindUnassignedActivePMJ`.
   - Prevents newly redeployed StatefulSets/Deployments from adopting lingering PMJs from deleted older generations.
3. **Single-Use PMJ Consumption Guard (Backlog 1.4 / ISSUE-6)**:
   - Added `Consumed bool` and `RestoredPodUID string` to `PodMigrationJobStatus`.
   - Marked `status.consumed = true` in `PodGateReconciler` upon releasing the scheduling gate.
   - Filtered out consumed PMJs in `FindUnassignedActivePMJ` to prevent duplicate restores if a restored pod crashes post-restore.
4. **Resilience Refactoring**:
   - Consolidated parent resolution into `util.ResolveParentWorkload` across `eviction_webhook.go`, `replacement_webhook.go`, and `pod_gate_controller.go` with graceful `NotFound` handling.

### Verification
- **Unit Tests**: Full test suite passing with race detector (`go test -v -race ./...` -> 100% PASS, 0 race conditions).
- **Independent Review**: Clean review report verifying semantic equivalence, fail-open/fail-closed properties, and concurrency safety.
- **E2E Validation**: 21 / 21 workloads validated on GKE Standard cluster `lpm-fresh-e2e`:
  `redis`, `dragonfly`, `vault`, `minio`, `nginx`, `haproxy`, `traefik`, `caddy`, `python`, `consul`, `mysql`, `mariadb`, `zookeeper`, `kafka`, `memcached`, `valkey`, `etcd`, `nats`, `postgres`, `node`, `go`.