### PR TITLE
feat: verify restore outcome on replacement pod and introduce Restoring phase

### DIFF
--- a/controller/api/v1alpha1/podmigrationjob_types.go
+++ b/controller/api/v1alpha1/podmigrationjob_types.go
@@ -38,6 +38,10 @@ type PodMigrationJobStatus struct {
 	// +optional
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 
+	// RestoringStartTime is the timestamp when this job transitioned to the Restoring phase.
+	// +optional
+	RestoringStartTime *metav1.Time `json:"restoringStartTime,omitempty"`
+
 	// Consumed indicates whether this migration snapshot has already been adopted by a replacement pod.
 	// Once true, subsequent pods will ignore this PMJ, preventing cross-generational stale state resurrection.
 	// +optional

--- a/controller/api/v1alpha1/podmigrationjob_types.go
+++ b/controller/api/v1alpha1/podmigrationjob_types.go
@@ -47,6 +47,10 @@ type PodMigrationJobStatus struct {
 	// +optional
 	RestoredPodUID string `json:"restoredPodUID,omitempty"`
 
+	// RestoredPodName stores the metadata.name of the replacement pod that adopted this PMJ.
+	// +optional
+	RestoredPodName string `json:"restoredPodName,omitempty"`
+
 	// Conditions represent the latest available observations of the job's current state.
 	// +optional
 	// +patchMergeKey=type

--- a/controller/api/v1alpha1/podmigrationjob_types.go
+++ b/controller/api/v1alpha1/podmigrationjob_types.go
@@ -17,11 +17,13 @@ type PodMigrationJobSpec struct {
 type PodMigrationJobPhase string
 
 const (
-	PodMigrationJobPhasePending      PodMigrationJobPhase = "Pending"
-	PodMigrationJobPhaseSnapshotting PodMigrationJobPhase = "Snapshotting"
-	PodMigrationJobPhaseEvicting     PodMigrationJobPhase = "Evicting"
-	PodMigrationJobPhaseSucceeded    PodMigrationJobPhase = "Succeeded"
-	PodMigrationJobPhaseFailed       PodMigrationJobPhase = "Failed"
+	PodMigrationJobPhasePending                 PodMigrationJobPhase = "Pending"
+	PodMigrationJobPhaseSnapshotting            PodMigrationJobPhase = "Snapshotting"
+	PodMigrationJobPhaseEvicting                PodMigrationJobPhase = "Evicting"
+	PodMigrationJobPhaseRestoring               PodMigrationJobPhase = "Restoring"
+	PodMigrationJobPhaseSucceeded               PodMigrationJobPhase = "Succeeded"
+	PodMigrationJobPhaseSucceededWithoutRestore PodMigrationJobPhase = "SucceededWithoutRestore"
+	PodMigrationJobPhaseFailed                  PodMigrationJobPhase = "Failed"
 )
 
 // PodMigrationJobStatus defines the observed state.

--- a/controller/cmd/main.go
+++ b/controller/cmd/main.go
@@ -95,8 +95,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err := (&controller.PodMigrationJobReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create PodMigrationJobReconciler")
 		os.Exit(1)

--- a/controller/config/crd/bases/podmigration.gke.io_podmigrationjobs.yaml
+++ b/controller/config/crd/bases/podmigration.gke.io_podmigrationjobs.yaml
@@ -155,6 +155,11 @@ spec:
                 description: RestoredPodUID records the UID of the replacement pod
                   that adopted this migration snapshot.
                 type: string
+              restoringStartTime:
+                description: RestoringStartTime is the timestamp when this job transitioned
+                  to the Restoring phase.
+                format: date-time
+                type: string
               snapshotRef:
                 description: SnapshotRef references the name of the created pod snapshot.
                 type: string

--- a/controller/config/crd/bases/podmigration.gke.io_podmigrationjobs.yaml
+++ b/controller/config/crd/bases/podmigration.gke.io_podmigrationjobs.yaml
@@ -147,6 +147,10 @@ spec:
                 items:
                   type: string
                 type: array
+              restoredPodName:
+                description: RestoredPodName stores the metadata.name of the replacement
+                  pod that adopted this PMJ.
+                type: string
               restoredPodUID:
                 description: RestoredPodUID records the UID of the replacement pod
                   that adopted this migration snapshot.

--- a/controller/config/rbac/role.yaml
+++ b/controller/config/rbac/role.yaml
@@ -8,15 +8,6 @@ rules:
   - ""
   resources:
   - events
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - persistentvolumeclaims
   verbs:
   - get

--- a/controller/config/rbac/role.yaml
+++ b/controller/config/rbac/role.yaml
@@ -7,6 +7,16 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - get

--- a/controller/deploy.yaml
+++ b/controller/deploy.yaml
@@ -18,15 +18,6 @@ rules:
   - ""
   resources:
   - events
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - persistentvolumeclaims
   verbs:
   - get

--- a/controller/deploy.yaml
+++ b/controller/deploy.yaml
@@ -17,6 +17,16 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - get

--- a/controller/internal/controller/crd_schema_test.go
+++ b/controller/internal/controller/crd_schema_test.go
@@ -70,6 +70,7 @@ func TestCRDSchema_PodMigrationJob_StatusFields(t *testing.T) {
 	// Update status fields
 	job.Status.Consumed = true
 	job.Status.RestoredPodUID = "uid-123"
+	job.Status.RestoredPodName = "pod-xyz"
 	if err := k8sClient.Status().Update(ctx, job); err != nil {
 		t.Fatalf("Failed to update PodMigrationJob status: %v", err)
 	}
@@ -85,5 +86,8 @@ func TestCRDSchema_PodMigrationJob_StatusFields(t *testing.T) {
 	}
 	if fetched.Status.RestoredPodUID != "uid-123" {
 		t.Errorf("Expected fetched.Status.RestoredPodUID == %q, got %q", "uid-123", fetched.Status.RestoredPodUID)
+	}
+	if fetched.Status.RestoredPodName != "pod-xyz" {
+		t.Errorf("Expected fetched.Status.RestoredPodName == %q, got %q", "pod-xyz", fetched.Status.RestoredPodName)
 	}
 }

--- a/controller/internal/controller/crd_schema_test.go
+++ b/controller/internal/controller/crd_schema_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,6 +72,8 @@ func TestCRDSchema_PodMigrationJob_StatusFields(t *testing.T) {
 	job.Status.Consumed = true
 	job.Status.RestoredPodUID = "uid-123"
 	job.Status.RestoredPodName = "pod-xyz"
+	now := metav1.NewTime(time.Now().Truncate(time.Second))
+	job.Status.RestoringStartTime = &now
 	if err := k8sClient.Status().Update(ctx, job); err != nil {
 		t.Fatalf("Failed to update PodMigrationJob status: %v", err)
 	}
@@ -89,5 +92,8 @@ func TestCRDSchema_PodMigrationJob_StatusFields(t *testing.T) {
 	}
 	if fetched.Status.RestoredPodName != "pod-xyz" {
 		t.Errorf("Expected fetched.Status.RestoredPodName == %q, got %q", "pod-xyz", fetched.Status.RestoredPodName)
+	}
+	if fetched.Status.RestoringStartTime == nil || !fetched.Status.RestoringStartTime.Equal(&now) {
+		t.Errorf("Expected fetched.Status.RestoringStartTime == %v, got %v", now, fetched.Status.RestoringStartTime)
 	}
 }

--- a/controller/internal/controller/pod_gate_controller.go
+++ b/controller/internal/controller/pod_gate_controller.go
@@ -114,8 +114,14 @@ func (r *PodGateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	phase := job.Status.Phase
-	if phase == pmv1alpha1.PodMigrationJobPhaseSucceeded || phase == pmv1alpha1.PodMigrationJobPhaseFailed {
-		logger.Info("Assigned PMJ has completed, releasing scheduling gate", "pmj", correctedPMJ, "phase", phase)
+	if phase == pmv1alpha1.PodMigrationJobPhaseRestoring ||
+		phase == pmv1alpha1.PodMigrationJobPhaseSucceeded ||
+		phase == pmv1alpha1.PodMigrationJobPhaseFailed {
+		if phase == pmv1alpha1.PodMigrationJobPhaseFailed {
+			logger.Info("Assigned PMJ failed; releasing scheduling gate for cold-start fallback", "pod", pod.Name, "pmj", correctedPMJ)
+		} else {
+			logger.Info("Assigned PMJ snapshot is durable; releasing scheduling gate and injecting snapshot ref", "pod", pod.Name, "pmj", correctedPMJ, "snapshot", job.Status.SnapshotRef)
+		}
 
 		if job.Status.Consumed && job.Status.RestoredPodUID != "" && job.Status.RestoredPodUID != string(pod.UID) {
 			logger.Info("Assigned PMJ was already consumed by a different pod, releasing gate with cold-start bypass",
@@ -129,8 +135,8 @@ func (r *PodGateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, r.Update(ctx, pod)
 		}
 
-		// If succeeded, inject GKE's native snapshot name annotation to force correct restore mapping
-		if phase == pmv1alpha1.PodMigrationJobPhaseSucceeded && job.Status.SnapshotRef != "" {
+		// Inject GKE's native snapshot name annotation when snapshotRef is present and not Failed
+		if (phase == pmv1alpha1.PodMigrationJobPhaseRestoring || phase == pmv1alpha1.PodMigrationJobPhaseSucceeded) && job.Status.SnapshotRef != "" {
 			if pod.Annotations == nil {
 				pod.Annotations = make(map[string]string)
 			}

--- a/controller/internal/controller/pod_gate_controller.go
+++ b/controller/internal/controller/pod_gate_controller.go
@@ -116,9 +116,12 @@ func (r *PodGateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	phase := job.Status.Phase
 	if phase == pmv1alpha1.PodMigrationJobPhaseRestoring ||
 		phase == pmv1alpha1.PodMigrationJobPhaseSucceeded ||
+		phase == pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore ||
 		phase == pmv1alpha1.PodMigrationJobPhaseFailed {
-		if phase == pmv1alpha1.PodMigrationJobPhaseFailed {
-			logger.Info("Assigned PMJ failed; releasing scheduling gate for cold-start fallback", "pod", pod.Name, "pmj", correctedPMJ)
+		if phase == pmv1alpha1.PodMigrationJobPhaseFailed ||
+			phase == pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore {
+			logger.Info("Assigned PMJ completed without restore; releasing scheduling gate for cold-start fallback",
+				"pod", pod.Name, "pmj", correctedPMJ, "phase", phase)
 		} else {
 			logger.Info("Assigned PMJ snapshot is durable; releasing scheduling gate and injecting snapshot ref", "pod", pod.Name, "pmj", correctedPMJ, "snapshot", job.Status.SnapshotRef)
 		}

--- a/controller/internal/controller/pod_gate_controller.go
+++ b/controller/internal/controller/pod_gate_controller.go
@@ -148,6 +148,7 @@ func (r *PodGateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if !job.Status.Consumed {
 			job.Status.Consumed = true
 			job.Status.RestoredPodUID = string(pod.UID)
+			job.Status.RestoredPodName = pod.Name
 			if updateErr := r.Status().Update(ctx, job); updateErr != nil {
 				logger.Error(updateErr, "Failed to mark PMJ as consumed")
 				return ctrl.Result{}, updateErr

--- a/controller/internal/controller/pod_gate_controller_test.go
+++ b/controller/internal/controller/pod_gate_controller_test.go
@@ -141,6 +141,37 @@ func TestPodGateReconciler_Reconcile(t *testing.T) {
 			expectHasGate: false,
 		},
 		{
+			name: "Gated pod with SucceededWithoutRestore PMJ gets gate released without snapshot injection",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"pod-migration.gke.io/assigned-pmj": "pmj-test-pod",
+					},
+				},
+				Spec: corev1.PodSpec{
+					SchedulingGates: []corev1.PodSchedulingGate{
+						{Name: "gke.io/pod-migration-gate"},
+					},
+				},
+			},
+			pmj: &pmv1alpha1.PodMigrationJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pmj-test-pod",
+					Namespace: "default",
+				},
+				Spec: pmv1alpha1.PodMigrationJobSpec{
+					PodRef: corev1.LocalObjectReference{Name: "test-pod"},
+				},
+				Status: pmv1alpha1.PodMigrationJobStatus{
+					Phase:       pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore,
+					SnapshotRef: "some-snapshot-name",
+				},
+			},
+			expectHasGate: false,
+		},
+		{
 			name: "Gated pod with missing parent ReplicaSet (NotFound) still releases gate if PMJ succeeds",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -295,6 +326,12 @@ func TestPodGateReconciler_Reconcile(t *testing.T) {
 				snapName := updatedPod.Annotations["podsnapshot.gke.io/ps-name"]
 				if snapName != tt.pmj.Status.SnapshotRef {
 					t.Errorf("expected snapshot annotation %q, got %q", tt.pmj.Status.SnapshotRef, snapName)
+				}
+			}
+
+			if !tt.expectHasGate && tt.pmj != nil && (tt.pmj.Status.Phase == pmv1alpha1.PodMigrationJobPhaseFailed || tt.pmj.Status.Phase == pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore) {
+				if snapName := updatedPod.Annotations["podsnapshot.gke.io/ps-name"]; snapName != "" {
+					t.Errorf("expected no snapshot annotation, got %q", snapName)
 				}
 			}
 		})

--- a/controller/internal/controller/pod_gate_controller_test.go
+++ b/controller/internal/controller/pod_gate_controller_test.go
@@ -179,6 +179,69 @@ func TestPodGateReconciler_Reconcile(t *testing.T) {
 			},
 			expectHasGate: false,
 		},
+		{
+			name: "Gated pod with Restoring PMJ gets gate released & snapshot ref injected",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"pod-migration.gke.io/assigned-pmj": "pmj-test-pod",
+					},
+				},
+				Spec: corev1.PodSpec{
+					SchedulingGates: []corev1.PodSchedulingGate{
+						{Name: "gke.io/pod-migration-gate"},
+					},
+				},
+			},
+			pmj: &pmv1alpha1.PodMigrationJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pmj-test-pod",
+					Namespace: "default",
+				},
+				Spec: pmv1alpha1.PodMigrationJobSpec{
+					PodRef: corev1.LocalObjectReference{Name: "test-pod"},
+				},
+				Status: pmv1alpha1.PodMigrationJobStatus{
+					Phase:       pmv1alpha1.PodMigrationJobPhaseRestoring,
+					SnapshotRef: "some-snapshot-name",
+				},
+			},
+			expectHasGate: false,
+		},
+		{
+			name: "Gated pod with Evicting PMJ does not release gate until Restoring",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"pod-migration.gke.io/assigned-pmj": "pmj-test-pod",
+					},
+				},
+				Spec: corev1.PodSpec{
+					SchedulingGates: []corev1.PodSchedulingGate{
+						{Name: "gke.io/pod-migration-gate"},
+					},
+				},
+			},
+			pmj: &pmv1alpha1.PodMigrationJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pmj-test-pod",
+					Namespace: "default",
+				},
+				Spec: pmv1alpha1.PodMigrationJobSpec{
+					PodRef: corev1.LocalObjectReference{Name: "test-pod"},
+				},
+				Status: pmv1alpha1.PodMigrationJobStatus{
+					Phase:       pmv1alpha1.PodMigrationJobPhaseEvicting,
+					SnapshotRef: "some-snapshot-name",
+					PVsToDetach: []string{},
+				},
+			},
+			expectHasGate: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -228,7 +291,7 @@ func TestPodGateReconciler_Reconcile(t *testing.T) {
 				t.Errorf("expected scheduling gate presence: %t, got: %t", tt.expectHasGate, hasGate)
 			}
 
-			if !tt.expectHasGate && tt.pmj != nil && tt.pmj.Status.Phase == pmv1alpha1.PodMigrationJobPhaseSucceeded {
+			if !tt.expectHasGate && tt.pmj != nil && (tt.pmj.Status.Phase == pmv1alpha1.PodMigrationJobPhaseSucceeded || tt.pmj.Status.Phase == pmv1alpha1.PodMigrationJobPhaseRestoring) {
 				snapName := updatedPod.Annotations["podsnapshot.gke.io/ps-name"]
 				if snapName != tt.pmj.Status.SnapshotRef {
 					t.Errorf("expected snapshot annotation %q, got %q", tt.pmj.Status.SnapshotRef, snapName)

--- a/controller/internal/controller/pod_gate_controller_test.go
+++ b/controller/internal/controller/pod_gate_controller_test.go
@@ -844,3 +844,83 @@ func TestPodGateReconciler_Reconcile_AlreadyConsumedPMJ_ReleasesGateWithColdStar
 		t.Errorf("expected pod-migration.gke.io/assigned-pmj annotation to be deleted, got %q", val)
 	}
 }
+
+func TestPodGateReconciler_Reconcile_RecordsRestoredPodNameAndUID(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	namespace := "default"
+	pmjName := "pmj-test"
+	podName := "test-replacement-pod"
+	podUID := types.UID("uid-replacement-123")
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      podName,
+			UID:       podUID,
+			Annotations: map[string]string{
+				"pod-migration.gke.io/assigned-pmj": pmjName,
+			},
+		},
+		Spec: corev1.PodSpec{
+			SchedulingGates: []corev1.PodSchedulingGate{
+				{Name: "gke.io/pod-migration-gate"},
+			},
+		},
+	}
+
+	pmj := &pmv1alpha1.PodMigrationJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      pmjName,
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef:       corev1.LocalObjectReference{Name: "orig-pod"},
+			TargetPodUID: "orig-pod-uid",
+		},
+		Status: pmv1alpha1.PodMigrationJobStatus{
+			Phase:       pmv1alpha1.PodMigrationJobPhaseRestoring,
+			SnapshotRef: "snapshot-123",
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+		WithObjects(pod, pmj).
+		Build()
+
+	r := &PodGateReconciler{
+		Client: cl,
+		Scheme: scheme,
+	}
+
+	ctx := context.Background()
+	_, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      podName,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updatedPMJ := &pmv1alpha1.PodMigrationJob{}
+	err = cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: pmjName}, updatedPMJ)
+	if err != nil {
+		t.Fatalf("failed to fetch updated PMJ: %v", err)
+	}
+
+	if !updatedPMJ.Status.Consumed {
+		t.Errorf("expected PMJ Consumed to be true, got false")
+	}
+	if updatedPMJ.Status.RestoredPodUID != string(podUID) {
+		t.Errorf("expected PMJ RestoredPodUID == %q, got %q", string(podUID), updatedPMJ.Status.RestoredPodUID)
+	}
+	if updatedPMJ.Status.RestoredPodName != podName {
+		t.Errorf("expected PMJ RestoredPodName == %q, got %q", podName, updatedPMJ.Status.RestoredPodName)
+	}
+}

--- a/controller/internal/controller/podmigrationjob_controller.go
+++ b/controller/internal/controller/podmigrationjob_controller.go
@@ -379,6 +379,8 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 		// 4.4. Once all PVs are detached, transition the PMJ phase to Restoring.
 		job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseRestoring
+		restoringNow := metav1.Now()
+		job.Status.RestoringStartTime = &restoringNow
 		meta.SetStatusCondition(&job.Status.Conditions, metav1.Condition{
 			Type:               "Ready",
 			Status:             metav1.ConditionFalse,
@@ -395,9 +397,19 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, nil
 
 	case pmv1alpha1.PodMigrationJobPhaseRestoring:
-		// 1. 5-minute safety ceiling
+		// 1. Ensure RestoringStartTime is initialized
+		if job.Status.RestoringStartTime == nil {
+			now := metav1.Now()
+			job.Status.RestoringStartTime = &now
+			if err := r.Status().Update(ctx, job); err != nil {
+				logger.Error(err, "Failed to initialize RestoringStartTime")
+				return ctrl.Result{}, err
+			}
+		}
+
+		// 2. 5-minute safety ceiling measured from RestoringStartTime
 		const restoreTimeout = 5 * time.Minute
-		if time.Since(job.CreationTimestamp.Time) > restoreTimeout {
+		if time.Since(job.Status.RestoringStartTime.Time) > restoreTimeout {
 			logger.Info("Restore timeout reached (5m), marking SucceededWithoutRestore", "job", job.Name, "pod", podName)
 			job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore
 			now := metav1.Now()

--- a/controller/internal/controller/podmigrationjob_controller.go
+++ b/controller/internal/controller/podmigrationjob_controller.go
@@ -25,6 +25,7 @@ import (
 // PodMigrationJobReconciler reconciles a PodMigrationJob object.
 type PodMigrationJobReconciler struct {
 	client.Client
+	APIReader        client.Reader
 	Scheme           *runtime.Scheme
 	SnapshotProvider snapshot.Provider
 }
@@ -501,7 +502,12 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 
 		// 5. Check for GKE PodSnapshots cold-start fallback Warning Event
-		if r.hasColdStartFallbackEvent(ctx, replacementPod) {
+		hasFallback, err := r.hasColdStartFallbackEvent(ctx, job, replacementPod)
+		if err != nil {
+			logger.Error(err, "Failed to query events for replacement pod")
+			return ctrl.Result{}, err
+		}
+		if hasFallback {
 			logger.Info("GKE runtime skipped snapshot restore and fell back to cold start", "pod", replacementPod.Name)
 			job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore
 			now := metav1.Now()
@@ -572,30 +578,54 @@ func isPodReady(pod *corev1.Pod) bool {
 	return false
 }
 
-func (r *PodMigrationJobReconciler) hasColdStartFallbackEvent(ctx context.Context, pod *corev1.Pod) bool {
+func (r *PodMigrationJobReconciler) hasColdStartFallbackEvent(ctx context.Context, job *pmv1alpha1.PodMigrationJob, pod *corev1.Pod) (bool, error) {
 	if pod == nil {
-		return false
+		return false, nil
 	}
+
+	reader := r.APIReader
+	if reader == nil {
+		reader = r.Client
+	}
+
 	eventList := &corev1.EventList{}
-	if err := r.List(ctx, eventList, client.InNamespace(pod.Namespace)); err != nil {
-		return false
+	listOpts := []client.ListOption{
+		client.InNamespace(pod.Namespace),
+		client.MatchingFields{"involvedObject.uid": string(pod.UID)},
 	}
+	if err := reader.List(ctx, eventList, listOpts...); err != nil {
+		return false, fmt.Errorf("failed to list events for replacement pod %s: %w", pod.Name, err)
+	}
+
 	for _, event := range eventList.Items {
-		if event.InvolvedObject.UID == pod.UID {
-			if event.Reason == "FallbackToColdStart" ||
-				event.Reason == "FailedRestore" ||
-				event.Reason == "RestoreFailed" ||
-				event.Reason == "SkipRestore" ||
-				(event.Type == corev1.EventTypeWarning && strings.Contains(strings.ToLower(event.Message), "falling back to a cold start")) ||
-				(event.Type == corev1.EventTypeWarning && strings.Contains(strings.ToLower(event.Message), "failed to restore")) ||
-				(event.Type == corev1.EventTypeWarning && strings.Contains(strings.ToLower(event.Message), "skipped restore")) ||
-				strings.Contains(strings.ToLower(event.Message), "cold start") ||
-				strings.Contains(strings.ToLower(event.Message), "fallback") {
-				return true
+		if event.InvolvedObject.UID != pod.UID {
+			continue
+		}
+
+		// Ignore events timestamped before this migration's Restoring phase started
+		if job != nil && job.Status.RestoringStartTime != nil && !event.LastTimestamp.IsZero() {
+			if event.LastTimestamp.Before(job.Status.RestoringStartTime) {
+				continue
+			}
+		}
+
+		// Only Warning events indicate an abnormal restore fallback
+		if event.Type == corev1.EventTypeWarning {
+			msg := strings.ToLower(event.Message)
+			reason := event.Reason
+			if reason == "FallbackToColdStart" ||
+				reason == "FailedRestore" ||
+				reason == "RestoreFailed" ||
+				reason == "SkipRestore" ||
+				reason == "GKEPodSnapshotting" ||
+				strings.Contains(msg, "falling back to a cold start") ||
+				strings.Contains(msg, "failed to restore") ||
+				strings.Contains(msg, "skipped restore") {
+				return true, nil
 			}
 		}
 	}
-	return false
+	return false, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controller/internal/controller/podmigrationjob_controller.go
+++ b/controller/internal/controller/podmigrationjob_controller.go
@@ -424,17 +424,17 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 
 		// 2. Wait until replacement pod has claimed the PMJ at the gate
-		if !job.Status.Consumed || job.Status.RestoredPodUID == "" {
+		if !job.Status.Consumed || job.Status.RestoredPodUID == "" || job.Status.RestoredPodName == "" {
 			logger.Info("PMJ is Restoring but not yet consumed by a replacement pod; waiting...", "job", job.Name)
 			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 		}
 
 		// 3. Fetch replacement pod by Name
 		replacementPod := &corev1.Pod{}
-		err = r.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: podName}, replacementPod)
+		err = r.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: job.Status.RestoredPodName}, replacementPod)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				logger.Info("Replacement pod not found yet; waiting...", "pod", podName)
+				logger.Info("Replacement pod not found yet; waiting...", "pod", job.Status.RestoredPodName)
 				return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 			}
 			logger.Error(err, "Failed to get replacement pod in Restoring phase")

--- a/controller/internal/controller/podmigrationjob_controller.go
+++ b/controller/internal/controller/podmigrationjob_controller.go
@@ -43,7 +43,7 @@ func (r *PodMigrationJobReconciler) getSnapshotProvider() snapshot.Provider {
 // +kubebuilder:rbac:groups=podsnapshot.gke.io,resources=podsnapshots/status,verbs=get
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattachments,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=events,verbs=create;get;list;patch;watch
+// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch
 
 // Reconcile drives the state machine of the PodMigrationJob.

--- a/controller/internal/controller/podmigrationjob_controller.go
+++ b/controller/internal/controller/podmigrationjob_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -18,6 +19,7 @@ import (
 
 	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
 	"github.com/gke-labs/pod-migration/controller/internal/snapshot"
+	"github.com/gke-labs/pod-migration/controller/internal/util"
 )
 
 // PodMigrationJobReconciler reconciles a PodMigrationJob object.
@@ -41,6 +43,7 @@ func (r *PodMigrationJobReconciler) getSnapshotProvider() snapshot.Provider {
 // +kubebuilder:rbac:groups=podsnapshot.gke.io,resources=podsnapshots/status,verbs=get
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattachments,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;get;list;patch;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch
 
 // Reconcile drives the state machine of the PodMigrationJob.
@@ -104,6 +107,7 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Garbage collect completed PMJs after 5 minutes
 	if job.Status.Phase == pmv1alpha1.PodMigrationJobPhaseSucceeded ||
+		job.Status.Phase == pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore ||
 		job.Status.Phase == pmv1alpha1.PodMigrationJobPhaseFailed {
 
 		if job.Status.CompletionTime != nil {
@@ -373,27 +377,213 @@ func (r *PodMigrationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			logger.Info("All volumes detached successfully")
 		}
 
-		// 4.4. Once all PVs are detached, transition the PMJ phase to Succeeded.
-		job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseSucceeded
-		now := metav1.Now()
-		job.Status.CompletionTime = &now
+		// 4.4. Once all PVs are detached, transition the PMJ phase to Restoring.
+		job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseRestoring
 		meta.SetStatusCondition(&job.Status.Conditions, metav1.Condition{
 			Type:               "Ready",
-			Status:             metav1.ConditionTrue,
-			Reason:             "MigrationSucceeded",
-			Message:            "Pod migration completed successfully",
+			Status:             metav1.ConditionFalse,
+			Reason:             "RestoringState",
+			Message:            "Snapshot durable and PVs detached; waiting for replacement pod restore",
 			ObservedGeneration: job.Generation,
 		})
 		err = r.Status().Update(ctx, job)
 		if err != nil {
-			logger.Error(err, "Failed to update job status to Succeeded")
+			logger.Error(err, "Failed to update job status to Restoring")
 			return ctrl.Result{}, err
 		}
-		logger.Info("PodMigrationJob completed successfully!")
+		logger.Info("PodMigrationJob transitioned to Restoring phase", "pod", podName)
 		return ctrl.Result{}, nil
+
+	case pmv1alpha1.PodMigrationJobPhaseRestoring:
+		// 1. 5-minute safety ceiling
+		const restoreTimeout = 5 * time.Minute
+		if time.Since(job.CreationTimestamp.Time) > restoreTimeout {
+			logger.Info("Restore timeout reached (5m), marking SucceededWithoutRestore", "job", job.Name, "pod", podName)
+			job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore
+			now := metav1.Now()
+			job.Status.CompletionTime = &now
+			meta.SetStatusCondition(&job.Status.Conditions, metav1.Condition{
+				Type:               "Restored",
+				Status:             metav1.ConditionFalse,
+				Reason:             "RestoreTimeout",
+				Message:            "Restore timed out after 5 minutes",
+				ObservedGeneration: job.Generation,
+			})
+			meta.SetStatusCondition(&job.Status.Conditions, metav1.Condition{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				Reason:             "RestoreTimeout",
+				Message:            "Restore timed out after 5 minutes",
+				ObservedGeneration: job.Generation,
+			})
+			if err := r.Status().Update(ctx, job); err != nil {
+				logger.Error(err, "Failed to update job status on restore timeout")
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+
+		// 2. Wait until replacement pod has claimed the PMJ at the gate
+		if !job.Status.Consumed || job.Status.RestoredPodUID == "" {
+			logger.Info("PMJ is Restoring but not yet consumed by a replacement pod; waiting...", "job", job.Name)
+			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+		}
+
+		// 3. Fetch replacement pod by Name
+		replacementPod := &corev1.Pod{}
+		err = r.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: podName}, replacementPod)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.Info("Replacement pod not found yet; waiting...", "pod", podName)
+				return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+			}
+			logger.Error(err, "Failed to get replacement pod in Restoring phase")
+			return ctrl.Result{}, err
+		}
+
+		// 4. Strict UID Assertion: Ensure we are evaluating the exact pod instance that adopted the snapshot
+		if string(replacementPod.UID) != job.Status.RestoredPodUID {
+			logger.Info("Pod with name exists but UID mismatch (replacement pod was recreated)",
+				"expectedUID", job.Status.RestoredPodUID, "actualUID", replacementPod.UID)
+
+			const mismatchGracePeriod = 30 * time.Second
+			mismatchSinceStr := job.Annotations[util.AnnotationMismatchSince]
+			if mismatchSinceStr == "" {
+				if job.Annotations == nil {
+					job.Annotations = make(map[string]string)
+				}
+				job.Annotations[util.AnnotationMismatchSince] = time.Now().Format(time.RFC3339)
+				if err := r.Update(ctx, job); err != nil {
+					return ctrl.Result{}, err
+				}
+				return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+			}
+
+			mismatchSince, err := time.Parse(time.RFC3339, mismatchSinceStr)
+			if err != nil || time.Since(mismatchSince) > mismatchGracePeriod {
+				logger.Info("Replacement pod UID mismatch persisted > 30s; fast-failing to SucceededWithoutRestore", "job", job.Name)
+				job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore
+				now := metav1.Now()
+				job.Status.CompletionTime = &now
+				meta.SetStatusCondition(&job.Status.Conditions, metav1.Condition{
+					Type:               "Restored",
+					Status:             metav1.ConditionFalse,
+					Reason:             "ReplacementPodMismatch",
+					Message:            "Replacement pod was deleted and recreated (UID mismatch persisted > 30s)",
+					ObservedGeneration: job.Generation,
+				})
+				meta.SetStatusCondition(&job.Status.Conditions, metav1.Condition{
+					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					Reason:             "ReplacementPodMismatch",
+					Message:            "Workload recreated with new instance; migration tracking concluded",
+					ObservedGeneration: job.Generation,
+				})
+				if err := r.Status().Update(ctx, job); err != nil {
+					return ctrl.Result{}, err
+				}
+				return ctrl.Result{}, nil
+			}
+
+			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+		}
+
+		// 5. Check for GKE PodSnapshots cold-start fallback Warning Event
+		if r.hasColdStartFallbackEvent(ctx, replacementPod) {
+			logger.Info("GKE runtime skipped snapshot restore and fell back to cold start", "pod", replacementPod.Name)
+			job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore
+			now := metav1.Now()
+			job.Status.CompletionTime = &now
+			meta.SetStatusCondition(&job.Status.Conditions, metav1.Condition{
+				Type:               "Restored",
+				Status:             metav1.ConditionFalse,
+				Reason:             "FallbackToColdStart",
+				Message:            "GKE runtime skipped snapshot restore and fell back to cold start",
+				ObservedGeneration: job.Generation,
+			})
+			meta.SetStatusCondition(&job.Status.Conditions, metav1.Condition{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				Reason:             "FallbackToColdStart",
+				Message:            "GKE runtime skipped snapshot restore and fell back to cold start",
+				ObservedGeneration: job.Generation,
+			})
+			if err := r.Status().Update(ctx, job); err != nil {
+				logger.Error(err, "Failed to update job status to SucceededWithoutRestore")
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+
+		// 6. Check if replacement pod has achieved PodReady condition (Verified Restore)
+		if isPodReady(replacementPod) {
+			logger.Info("Pod state restored from snapshot and replacement pod is Ready", "pod", replacementPod.Name)
+			job.Status.Phase = pmv1alpha1.PodMigrationJobPhaseSucceeded
+			now := metav1.Now()
+			job.Status.CompletionTime = &now
+			meta.SetStatusCondition(&job.Status.Conditions, metav1.Condition{
+				Type:               "Restored",
+				Status:             metav1.ConditionTrue,
+				Reason:             "RestoreVerified",
+				Message:            "Pod state restored from snapshot and replacement pod is Ready",
+				ObservedGeneration: job.Generation,
+			})
+			meta.SetStatusCondition(&job.Status.Conditions, metav1.Condition{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				Reason:             "RestoreVerified",
+				Message:            "Pod state restored from snapshot and replacement pod is Ready",
+				ObservedGeneration: job.Generation,
+			})
+			if err := r.Status().Update(ctx, job); err != nil {
+				logger.Error(err, "Failed to update job status to Succeeded")
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *PodMigrationJobReconciler) hasColdStartFallbackEvent(ctx context.Context, pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	eventList := &corev1.EventList{}
+	if err := r.List(ctx, eventList, client.InNamespace(pod.Namespace)); err != nil {
+		return false
+	}
+	for _, event := range eventList.Items {
+		if event.InvolvedObject.UID == pod.UID {
+			if event.Reason == "FallbackToColdStart" ||
+				event.Reason == "FailedRestore" ||
+				event.Reason == "RestoreFailed" ||
+				event.Reason == "SkipRestore" ||
+				(event.Type == corev1.EventTypeWarning && strings.Contains(strings.ToLower(event.Message), "falling back to a cold start")) ||
+				(event.Type == corev1.EventTypeWarning && strings.Contains(strings.ToLower(event.Message), "failed to restore")) ||
+				(event.Type == corev1.EventTypeWarning && strings.Contains(strings.ToLower(event.Message), "skipped restore")) ||
+				strings.Contains(strings.ToLower(event.Message), "cold start") ||
+				strings.Contains(strings.ToLower(event.Message), "fallback") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controller/internal/controller/podmigrationjob_controller_test.go
+++ b/controller/internal/controller/podmigrationjob_controller_test.go
@@ -15,11 +15,23 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	pmv1alpha1 "github.com/gke-labs/pod-migration/controller/api/v1alpha1"
 	"github.com/gke-labs/pod-migration/controller/internal/util"
 )
+
+func newFakeClientBuilderWithEventIndex(scheme *runtime.Scheme) *fake.ClientBuilder {
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&corev1.Event{}, "involvedObject.uid", func(rawObj client.Object) []string {
+			if event, ok := rawObj.(*corev1.Event); ok {
+				return []string{string(event.InvolvedObject.UID)}
+			}
+			return nil
+		})
+}
 
 func TestPodMigrationJobReconciler_Pending(t *testing.T) {
 	scheme := runtime.NewScheme()
@@ -1324,8 +1336,7 @@ func TestPodMigrationJobReconciler_Restoring_Success(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := newFakeClientBuilderWithEventIndex(scheme).
 		WithObjects(replacementPod, pmj).
 		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
 		Build()
@@ -1415,8 +1426,7 @@ func TestPodMigrationJobReconciler_Restoring_Success_DifferentReplacementPodName
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := newFakeClientBuilderWithEventIndex(scheme).
 		WithObjects(replacementPod, pmj).
 		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
 		Build()
@@ -1494,6 +1504,7 @@ func TestPodMigrationJobReconciler_Restoring_ColdStartFallback(t *testing.T) {
 			Name:      podName,
 			UID:       types.UID(podUID),
 		},
+		Type:    corev1.EventTypeWarning,
 		Reason:  "FallbackToColdStart",
 		Message: "GKE runtime skipped snapshot restore and fell back to cold start",
 	}
@@ -1519,8 +1530,7 @@ func TestPodMigrationJobReconciler_Restoring_ColdStartFallback(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := newFakeClientBuilderWithEventIndex(scheme).
 		WithObjects(replacementPod, event, pmj).
 		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
 		Build()
@@ -1558,6 +1568,211 @@ func TestPodMigrationJobReconciler_Restoring_ColdStartFallback(t *testing.T) {
 	}
 	if restoredCond.Status != metav1.ConditionFalse || restoredCond.Reason != "FallbackToColdStart" {
 		t.Errorf("Expected Restored condition False/FallbackToColdStart, got %+v", restoredCond)
+	}
+}
+
+func TestPodMigrationJobReconciler_Restoring_IgnoresNormalEventsWithFallbackKeyword(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	namespace := "default"
+	podName := "test-pod"
+	podUID := "restored-uid-1234"
+	jobName := "pmj-" + podName
+
+	replacementPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      podName,
+			UID:       types.UID(podUID),
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "cni-event",
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      "Pod",
+			Namespace: namespace,
+			Name:      podName,
+			UID:       types.UID(podUID),
+		},
+		Type:    corev1.EventTypeNormal,
+		Reason:  "CNIFallback",
+		Message: "fallback route configured",
+	}
+
+	pmj := &pmv1alpha1.PodMigrationJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "podmigration.gke.io/v1alpha1",
+			Kind:       "PodMigrationJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              jobName,
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef: corev1.LocalObjectReference{Name: podName},
+		},
+		Status: pmv1alpha1.PodMigrationJobStatus{
+			Phase:           pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed:        true,
+			RestoredPodUID:  podUID,
+			RestoredPodName: podName,
+		},
+	}
+
+	fakeClient := newFakeClientBuilderWithEventIndex(scheme).
+		WithObjects(replacementPod, event, pmj).
+		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+		Build()
+
+	r := &PodMigrationJobReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: jobName},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Errorf("Expected no requeue, got: %+v", res)
+	}
+
+	updatedPMJ := &pmv1alpha1.PodMigrationJob{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
+	if err != nil {
+		t.Fatalf("Failed to get PMJ: %v", err)
+	}
+	if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseSucceeded {
+		t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseSucceeded, updatedPMJ.Status.Phase)
+	}
+
+	restoredCond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Restored")
+	if restoredCond == nil {
+		t.Fatalf("Expected Restored condition to be set")
+	}
+	if restoredCond.Status != metav1.ConditionTrue || restoredCond.Reason != "RestoreVerified" {
+		t.Errorf("Expected Restored condition True/RestoreVerified, got %+v", restoredCond)
+	}
+}
+
+func TestPodMigrationJobReconciler_Restoring_IgnoresStaleWarningEventsBeforeRestoringStartTime(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	namespace := "default"
+	podName := "test-pod"
+	podUID := "restored-uid-1234"
+	jobName := "pmj-" + podName
+
+	replacementPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      podName,
+			UID:       types.UID(podUID),
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "stale-fallback-event",
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      "Pod",
+			Namespace: namespace,
+			Name:      podName,
+			UID:       types.UID(podUID),
+		},
+		Type:          corev1.EventTypeWarning,
+		Reason:        "FallbackToColdStart",
+		Message:       "falling back to a cold start",
+		LastTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)},
+	}
+
+	restoringStartTime := metav1.Time{Time: time.Now().Add(-2 * time.Minute)}
+	pmj := &pmv1alpha1.PodMigrationJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "podmigration.gke.io/v1alpha1",
+			Kind:       "PodMigrationJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              jobName,
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef: corev1.LocalObjectReference{Name: podName},
+		},
+		Status: pmv1alpha1.PodMigrationJobStatus{
+			Phase:              pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed:           true,
+			RestoredPodUID:     podUID,
+			RestoredPodName:    podName,
+			RestoringStartTime: &restoringStartTime,
+		},
+	}
+
+	fakeClient := newFakeClientBuilderWithEventIndex(scheme).
+		WithObjects(replacementPod, event, pmj).
+		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+		Build()
+
+	r := &PodMigrationJobReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: jobName},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Errorf("Expected no requeue, got: %+v", res)
+	}
+
+	updatedPMJ := &pmv1alpha1.PodMigrationJob{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
+	if err != nil {
+		t.Fatalf("Failed to get PMJ: %v", err)
+	}
+	if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseSucceeded {
+		t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseSucceeded, updatedPMJ.Status.Phase)
+	}
+
+	restoredCond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Restored")
+	if restoredCond == nil {
+		t.Fatalf("Expected Restored condition to be set")
+	}
+	if restoredCond.Status != metav1.ConditionTrue || restoredCond.Reason != "RestoreVerified" {
+		t.Errorf("Expected Restored condition True/RestoreVerified, got %+v", restoredCond)
 	}
 }
 

--- a/controller/internal/controller/podmigrationjob_controller_test.go
+++ b/controller/internal/controller/podmigrationjob_controller_test.go
@@ -1179,6 +1179,9 @@ func TestPodMigrationJobReconciler_Evicting_Success(t *testing.T) {
 	if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseRestoring {
 		t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseRestoring, updatedPMJ.Status.Phase)
 	}
+	if updatedPMJ.Status.RestoringStartTime == nil {
+		t.Errorf("Expected RestoringStartTime to be set, but got nil")
+	}
 
 	cond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Ready")
 	if cond == nil {
@@ -1567,21 +1570,22 @@ func TestPodMigrationJobReconciler_Restoring_Timeout(t *testing.T) {
 	podName := "test-pod"
 	jobName := "pmj-" + podName
 
+	restoringStartTime := metav1.NewTime(time.Now().Add(-6 * time.Minute))
 	pmj := &pmv1alpha1.PodMigrationJob{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "podmigration.gke.io/v1alpha1",
 			Kind:       "PodMigrationJob",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:         namespace,
-			Name:              jobName,
-			CreationTimestamp: metav1.NewTime(time.Now().Add(-6 * time.Minute)),
+			Namespace: namespace,
+			Name:      jobName,
 		},
 		Spec: pmv1alpha1.PodMigrationJobSpec{
 			PodRef: corev1.LocalObjectReference{Name: podName},
 		},
 		Status: pmv1alpha1.PodMigrationJobStatus{
-			Phase: pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Phase:              pmv1alpha1.PodMigrationJobPhaseRestoring,
+			RestoringStartTime: &restoringStartTime,
 		},
 	}
 
@@ -1621,6 +1625,69 @@ func TestPodMigrationJobReconciler_Restoring_Timeout(t *testing.T) {
 	restoredCond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Restored")
 	if restoredCond == nil || restoredCond.Reason != "RestoreTimeout" {
 		t.Errorf("Expected Restored condition with Reason=RestoreTimeout, got %+v", restoredCond)
+	}
+}
+
+func TestPodMigrationJobReconciler_Restoring_Timeout_MeasuredFromRestoringStartTimeNotCreationTimestamp(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	namespace := "default"
+	podName := "test-pod"
+	jobName := "pmj-" + podName
+
+	restoringStartTime := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	pmj := &pmv1alpha1.PodMigrationJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "podmigration.gke.io/v1alpha1",
+			Kind:       "PodMigrationJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              jobName,
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-8 * time.Minute)),
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef: corev1.LocalObjectReference{Name: podName},
+		},
+		Status: pmv1alpha1.PodMigrationJobStatus{
+			Phase:              pmv1alpha1.PodMigrationJobPhaseRestoring,
+			RestoringStartTime: &restoringStartTime,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pmj).
+		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+		Build()
+
+	r := &PodMigrationJobReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: jobName},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+	if res.RequeueAfter != 2*time.Second {
+		t.Errorf("Expected RequeueAfter 2s, got: %+v", res)
+	}
+
+	updatedPMJ := &pmv1alpha1.PodMigrationJob{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
+	if err != nil {
+		t.Fatalf("Failed to get PMJ: %v", err)
+	}
+	if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseRestoring {
+		t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseRestoring, updatedPMJ.Status.Phase)
+	}
+	if updatedPMJ.Status.CompletionTime != nil {
+		t.Errorf("Expected CompletionTime to be nil")
 	}
 }
 

--- a/controller/internal/controller/podmigrationjob_controller_test.go
+++ b/controller/internal/controller/podmigrationjob_controller_test.go
@@ -1201,44 +1201,76 @@ func TestPodMigrationJobReconciler_Restoring_WaitingForConsumed(t *testing.T) {
 	podName := "test-pod"
 	jobName := "pmj-" + podName
 
-	pmj := &pmv1alpha1.PodMigrationJob{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "podmigration.gke.io/v1alpha1",
-			Kind:       "PodMigrationJob",
+	tests := []struct {
+		name   string
+		status pmv1alpha1.PodMigrationJobStatus
+	}{
+		{
+			name: "Not consumed",
+			status: pmv1alpha1.PodMigrationJobStatus{
+				Phase:    pmv1alpha1.PodMigrationJobPhaseRestoring,
+				Consumed: false,
+			},
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:         namespace,
-			Name:              jobName,
-			CreationTimestamp: metav1.Now(),
+		{
+			name: "Consumed but empty RestoredPodUID",
+			status: pmv1alpha1.PodMigrationJobStatus{
+				Phase:           pmv1alpha1.PodMigrationJobPhaseRestoring,
+				Consumed:        true,
+				RestoredPodUID:  "",
+				RestoredPodName: "test-pod",
+			},
 		},
-		Spec: pmv1alpha1.PodMigrationJobSpec{
-			PodRef: corev1.LocalObjectReference{Name: podName},
-		},
-		Status: pmv1alpha1.PodMigrationJobStatus{
-			Phase:    pmv1alpha1.PodMigrationJobPhaseRestoring,
-			Consumed: false,
+		{
+			name: "Consumed but empty RestoredPodName",
+			status: pmv1alpha1.PodMigrationJobStatus{
+				Phase:           pmv1alpha1.PodMigrationJobPhaseRestoring,
+				Consumed:        true,
+				RestoredPodUID:  "uid-123",
+				RestoredPodName: "",
+			},
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(pmj).
-		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
-		Build()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pmj := &pmv1alpha1.PodMigrationJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "podmigration.gke.io/v1alpha1",
+					Kind:       "PodMigrationJob",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         namespace,
+					Name:              jobName,
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: pmv1alpha1.PodMigrationJobSpec{
+					PodRef: corev1.LocalObjectReference{Name: podName},
+				},
+				Status: tc.status,
+			}
 
-	r := &PodMigrationJobReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
-	}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(pmj).
+				WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+				Build()
 
-	res, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: namespace, Name: jobName},
-	})
-	if err != nil {
-		t.Fatalf("Reconcile failed: %v", err)
-	}
-	if res.RequeueAfter != 2*time.Second {
-		t.Errorf("Expected RequeueAfter 2s while waiting for pod gate consumption, got: %+v", res)
+			r := &PodMigrationJobReconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+			}
+
+			res, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Namespace: namespace, Name: jobName},
+			})
+			if err != nil {
+				t.Fatalf("Reconcile failed: %v", err)
+			}
+			if res.RequeueAfter != 2*time.Second {
+				t.Errorf("Expected RequeueAfter 2s while waiting for pod gate consumption, got: %+v", res)
+			}
+		})
 	}
 }
 
@@ -1282,9 +1314,101 @@ func TestPodMigrationJobReconciler_Restoring_Success(t *testing.T) {
 			PodRef: corev1.LocalObjectReference{Name: podName},
 		},
 		Status: pmv1alpha1.PodMigrationJobStatus{
-			Phase:          pmv1alpha1.PodMigrationJobPhaseRestoring,
-			Consumed:       true,
-			RestoredPodUID: podUID,
+			Phase:           pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed:        true,
+			RestoredPodUID:  podUID,
+			RestoredPodName: podName,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(replacementPod, pmj).
+		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+		Build()
+
+	r := &PodMigrationJobReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: jobName},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Errorf("Expected no requeue after success, got: %+v", res)
+	}
+
+	updatedPMJ := &pmv1alpha1.PodMigrationJob{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
+	if err != nil {
+		t.Fatalf("Failed to get PMJ: %v", err)
+	}
+	if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseSucceeded {
+		t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseSucceeded, updatedPMJ.Status.Phase)
+	}
+	if updatedPMJ.Status.CompletionTime == nil {
+		t.Errorf("Expected CompletionTime to be set")
+	}
+
+	restoredCond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Restored")
+	if restoredCond == nil {
+		t.Fatalf("Expected Restored condition to be set")
+	}
+	if restoredCond.Status != metav1.ConditionTrue || restoredCond.Reason != "RestoreVerified" {
+		t.Errorf("Expected Restored condition True/RestoreVerified, got %+v", restoredCond)
+	}
+}
+
+func TestPodMigrationJobReconciler_Restoring_Success_DifferentReplacementPodName(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	namespace := "default"
+	originPodName := "my-deploy-abc"
+	restoredPodName := "my-deploy-xyz"
+	restoredPodUID := "uid-xyz"
+	jobName := "pmj-" + originPodName
+
+	replacementPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      restoredPodName,
+			UID:       types.UID(restoredPodUID),
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	pmj := &pmv1alpha1.PodMigrationJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "podmigration.gke.io/v1alpha1",
+			Kind:       "PodMigrationJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              jobName,
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef:       corev1.LocalObjectReference{Name: originPodName},
+			TargetPodUID: "origin-uid-abc",
+		},
+		Status: pmv1alpha1.PodMigrationJobStatus{
+			Phase:           pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed:        true,
+			RestoredPodUID:  restoredPodUID,
+			RestoredPodName: restoredPodName,
 		},
 	}
 
@@ -1385,9 +1509,10 @@ func TestPodMigrationJobReconciler_Restoring_ColdStartFallback(t *testing.T) {
 			PodRef: corev1.LocalObjectReference{Name: podName},
 		},
 		Status: pmv1alpha1.PodMigrationJobStatus{
-			Phase:          pmv1alpha1.PodMigrationJobPhaseRestoring,
-			Consumed:       true,
-			RestoredPodUID: podUID,
+			Phase:           pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed:        true,
+			RestoredPodUID:  podUID,
+			RestoredPodName: podName,
 		},
 	}
 
@@ -1540,9 +1665,10 @@ func TestPodMigrationJobReconciler_Restoring_UIDMismatch_Initial(t *testing.T) {
 			PodRef: corev1.LocalObjectReference{Name: podName},
 		},
 		Status: pmv1alpha1.PodMigrationJobStatus{
-			Phase:          pmv1alpha1.PodMigrationJobPhaseRestoring,
-			Consumed:       true,
-			RestoredPodUID: expectedUID,
+			Phase:           pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed:        true,
+			RestoredPodUID:  expectedUID,
+			RestoredPodName: podName,
 		},
 	}
 
@@ -1624,9 +1750,10 @@ func TestPodMigrationJobReconciler_Restoring_UIDMismatch_PersistedTimeout(t *tes
 			PodRef: corev1.LocalObjectReference{Name: podName},
 		},
 		Status: pmv1alpha1.PodMigrationJobStatus{
-			Phase:          pmv1alpha1.PodMigrationJobPhaseRestoring,
-			Consumed:       true,
-			RestoredPodUID: expectedUID,
+			Phase:           pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed:        true,
+			RestoredPodUID:  expectedUID,
+			RestoredPodName: podName,
 		},
 	}
 
@@ -1718,9 +1845,10 @@ func TestPodMigrationJobReconciler_Restoring_UIDMismatch_MalformedAnnotation(t *
 			PodRef: corev1.LocalObjectReference{Name: podName},
 		},
 		Status: pmv1alpha1.PodMigrationJobStatus{
-			Phase:          pmv1alpha1.PodMigrationJobPhaseRestoring,
-			Consumed:       true,
-			RestoredPodUID: expectedUID,
+			Phase:           pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed:        true,
+			RestoredPodUID:  expectedUID,
+			RestoredPodName: podName,
 		},
 	}
 

--- a/controller/internal/controller/podmigrationjob_controller_test.go
+++ b/controller/internal/controller/podmigrationjob_controller_test.go
@@ -1167,10 +1167,148 @@ func TestPodMigrationJobReconciler_Evicting_Success(t *testing.T) {
 		t.Fatalf("Reconcile failed: %v", err)
 	}
 	if res.Requeue || res.RequeueAfter != 0 {
-		t.Errorf("Expected no requeue, got: %+v", res)
+		t.Errorf("Expected no requeue on transition to Restoring, got: %+v", res)
 	}
 
-	// Verify PMJ transitioned to Succeeded
+	// Verify PMJ transitioned to Restoring
+	updatedPMJ := &pmv1alpha1.PodMigrationJob{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
+	if err != nil {
+		t.Fatalf("Failed to get PMJ: %v", err)
+	}
+	if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseRestoring {
+		t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseRestoring, updatedPMJ.Status.Phase)
+	}
+
+	cond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Ready")
+	if cond == nil {
+		t.Fatalf("Expected Ready condition to be set, but it was nil")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Expected Ready condition status to be False, got %s", cond.Status)
+	}
+	if cond.Reason != "RestoringState" {
+		t.Errorf("Expected Ready condition reason to be 'RestoringState', got %q", cond.Reason)
+	}
+}
+
+func TestPodMigrationJobReconciler_Restoring_WaitingForConsumed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	namespace := "default"
+	podName := "test-pod"
+	jobName := "pmj-" + podName
+
+	pmj := &pmv1alpha1.PodMigrationJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "podmigration.gke.io/v1alpha1",
+			Kind:       "PodMigrationJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              jobName,
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef: corev1.LocalObjectReference{Name: podName},
+		},
+		Status: pmv1alpha1.PodMigrationJobStatus{
+			Phase:    pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed: false,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pmj).
+		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+		Build()
+
+	r := &PodMigrationJobReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: jobName},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+	if res.RequeueAfter != 2*time.Second {
+		t.Errorf("Expected RequeueAfter 2s while waiting for pod gate consumption, got: %+v", res)
+	}
+}
+
+func TestPodMigrationJobReconciler_Restoring_Success(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	namespace := "default"
+	podName := "test-pod"
+	podUID := "restored-uid-1234"
+	jobName := "pmj-" + podName
+
+	replacementPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      podName,
+			UID:       types.UID(podUID),
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	pmj := &pmv1alpha1.PodMigrationJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "podmigration.gke.io/v1alpha1",
+			Kind:       "PodMigrationJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              jobName,
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef: corev1.LocalObjectReference{Name: podName},
+		},
+		Status: pmv1alpha1.PodMigrationJobStatus{
+			Phase:          pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed:       true,
+			RestoredPodUID: podUID,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(replacementPod, pmj).
+		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+		Build()
+
+	r := &PodMigrationJobReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: jobName},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Errorf("Expected no requeue after success, got: %+v", res)
+	}
+
 	updatedPMJ := &pmv1alpha1.PodMigrationJob{}
 	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
 	if err != nil {
@@ -1183,14 +1321,449 @@ func TestPodMigrationJobReconciler_Evicting_Success(t *testing.T) {
 		t.Errorf("Expected CompletionTime to be set")
 	}
 
-	cond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Ready")
-	if cond == nil {
-		t.Fatalf("Expected Ready condition to be set, but it was nil")
+	restoredCond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Restored")
+	if restoredCond == nil {
+		t.Fatalf("Expected Restored condition to be set")
 	}
-	if cond.Status != metav1.ConditionTrue {
-		t.Errorf("Expected Ready condition status to be True, got %s", cond.Status)
+	if restoredCond.Status != metav1.ConditionTrue || restoredCond.Reason != "RestoreVerified" {
+		t.Errorf("Expected Restored condition True/RestoreVerified, got %+v", restoredCond)
 	}
-	if cond.Reason != "MigrationSucceeded" {
-		t.Errorf("Expected Ready condition reason to be 'MigrationSucceeded', got %q", cond.Reason)
+}
+
+func TestPodMigrationJobReconciler_Restoring_ColdStartFallback(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	namespace := "default"
+	podName := "test-pod"
+	podUID := "restored-uid-1234"
+	jobName := "pmj-" + podName
+
+	replacementPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      podName,
+			UID:       types.UID(podUID),
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "fallback-event",
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      "Pod",
+			Namespace: namespace,
+			Name:      podName,
+			UID:       types.UID(podUID),
+		},
+		Reason:  "FallbackToColdStart",
+		Message: "GKE runtime skipped snapshot restore and fell back to cold start",
+	}
+
+	pmj := &pmv1alpha1.PodMigrationJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "podmigration.gke.io/v1alpha1",
+			Kind:       "PodMigrationJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              jobName,
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef: corev1.LocalObjectReference{Name: podName},
+		},
+		Status: pmv1alpha1.PodMigrationJobStatus{
+			Phase:          pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed:       true,
+			RestoredPodUID: podUID,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(replacementPod, event, pmj).
+		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+		Build()
+
+	r := &PodMigrationJobReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: jobName},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Errorf("Expected no requeue, got: %+v", res)
+	}
+
+	updatedPMJ := &pmv1alpha1.PodMigrationJob{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
+	if err != nil {
+		t.Fatalf("Failed to get PMJ: %v", err)
+	}
+	if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore {
+		t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore, updatedPMJ.Status.Phase)
+	}
+	if updatedPMJ.Status.CompletionTime == nil {
+		t.Errorf("Expected CompletionTime to be set")
+	}
+
+	restoredCond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Restored")
+	if restoredCond == nil {
+		t.Fatalf("Expected Restored condition to be set")
+	}
+	if restoredCond.Status != metav1.ConditionFalse || restoredCond.Reason != "FallbackToColdStart" {
+		t.Errorf("Expected Restored condition False/FallbackToColdStart, got %+v", restoredCond)
+	}
+}
+
+func TestPodMigrationJobReconciler_Restoring_Timeout(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	namespace := "default"
+	podName := "test-pod"
+	jobName := "pmj-" + podName
+
+	pmj := &pmv1alpha1.PodMigrationJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "podmigration.gke.io/v1alpha1",
+			Kind:       "PodMigrationJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              jobName,
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-6 * time.Minute)),
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef: corev1.LocalObjectReference{Name: podName},
+		},
+		Status: pmv1alpha1.PodMigrationJobStatus{
+			Phase: pmv1alpha1.PodMigrationJobPhaseRestoring,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pmj).
+		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+		Build()
+
+	r := &PodMigrationJobReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: jobName},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Errorf("Expected no requeue on timeout, got: %+v", res)
+	}
+
+	updatedPMJ := &pmv1alpha1.PodMigrationJob{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
+	if err != nil {
+		t.Fatalf("Failed to get PMJ: %v", err)
+	}
+	if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore {
+		t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore, updatedPMJ.Status.Phase)
+	}
+	if updatedPMJ.Status.CompletionTime == nil {
+		t.Errorf("Expected CompletionTime to be set")
+	}
+
+	restoredCond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Restored")
+	if restoredCond == nil || restoredCond.Reason != "RestoreTimeout" {
+		t.Errorf("Expected Restored condition with Reason=RestoreTimeout, got %+v", restoredCond)
+	}
+}
+
+func TestPodMigrationJobReconciler_Restoring_UIDMismatch_Initial(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	namespace := "default"
+	podName := "test-pod"
+	expectedUID := "expected-uid-1234"
+	differentUID := "different-uid-5678"
+	jobName := "pmj-" + podName
+
+	replacementPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      podName,
+			UID:       types.UID(differentUID),
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	pmj := &pmv1alpha1.PodMigrationJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "podmigration.gke.io/v1alpha1",
+			Kind:       "PodMigrationJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              jobName,
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef: corev1.LocalObjectReference{Name: podName},
+		},
+		Status: pmv1alpha1.PodMigrationJobStatus{
+			Phase:          pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed:       true,
+			RestoredPodUID: expectedUID,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(replacementPod, pmj).
+		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+		Build()
+
+	r := &PodMigrationJobReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: jobName},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+	if res.RequeueAfter != 2*time.Second {
+		t.Errorf("Expected RequeueAfter 2s on initial UID mismatch, got: %+v", res)
+	}
+
+	updatedPMJ := &pmv1alpha1.PodMigrationJob{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
+	if err != nil {
+		t.Fatalf("Failed to get PMJ: %v", err)
+	}
+	if updatedPMJ.Annotations[util.AnnotationMismatchSince] == "" {
+		t.Errorf("Expected mismatch-since annotation to be set")
+	}
+	if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseRestoring {
+		t.Errorf("Expected phase to remain %s, got %s", pmv1alpha1.PodMigrationJobPhaseRestoring, updatedPMJ.Status.Phase)
+	}
+}
+
+func TestPodMigrationJobReconciler_Restoring_UIDMismatch_PersistedTimeout(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	namespace := "default"
+	podName := "test-pod"
+	expectedUID := "expected-uid-1234"
+	differentUID := "different-uid-5678"
+	jobName := "pmj-" + podName
+
+	replacementPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      podName,
+			UID:       types.UID(differentUID),
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	pmj := &pmv1alpha1.PodMigrationJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "podmigration.gke.io/v1alpha1",
+			Kind:       "PodMigrationJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      jobName,
+			Annotations: map[string]string{
+				util.AnnotationMismatchSince: time.Now().Add(-35 * time.Second).Format(time.RFC3339),
+			},
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef: corev1.LocalObjectReference{Name: podName},
+		},
+		Status: pmv1alpha1.PodMigrationJobStatus{
+			Phase:          pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed:       true,
+			RestoredPodUID: expectedUID,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(replacementPod, pmj).
+		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+		Build()
+
+	r := &PodMigrationJobReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: jobName},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Errorf("Expected no requeue after UID mismatch persisted >30s, got: %+v", res)
+	}
+
+	updatedPMJ := &pmv1alpha1.PodMigrationJob{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
+	if err != nil {
+		t.Fatalf("Failed to get PMJ: %v", err)
+	}
+	if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore {
+		t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore, updatedPMJ.Status.Phase)
+	}
+	if updatedPMJ.Status.CompletionTime == nil {
+		t.Errorf("Expected CompletionTime to be set")
+	}
+
+	restoredCond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Restored")
+	if restoredCond == nil || restoredCond.Reason != "ReplacementPodMismatch" || restoredCond.Status != metav1.ConditionFalse {
+		t.Errorf("Expected Restored condition False/ReplacementPodMismatch, got %+v", restoredCond)
+	}
+
+	readyCond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Ready")
+	if readyCond == nil || readyCond.Reason != "ReplacementPodMismatch" || readyCond.Status != metav1.ConditionTrue {
+		t.Errorf("Expected Ready condition True/ReplacementPodMismatch, got %+v", readyCond)
+	}
+}
+
+func TestPodMigrationJobReconciler_Restoring_UIDMismatch_MalformedAnnotation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = pmv1alpha1.AddToScheme(scheme)
+
+	namespace := "default"
+	podName := "test-pod"
+	expectedUID := "expected-uid-1234"
+	differentUID := "different-uid-5678"
+	jobName := "pmj-" + podName
+
+	replacementPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      podName,
+			UID:       types.UID(differentUID),
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	pmj := &pmv1alpha1.PodMigrationJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "podmigration.gke.io/v1alpha1",
+			Kind:       "PodMigrationJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      jobName,
+			Annotations: map[string]string{
+				util.AnnotationMismatchSince: "invalid-timestamp",
+			},
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: pmv1alpha1.PodMigrationJobSpec{
+			PodRef: corev1.LocalObjectReference{Name: podName},
+		},
+		Status: pmv1alpha1.PodMigrationJobStatus{
+			Phase:          pmv1alpha1.PodMigrationJobPhaseRestoring,
+			Consumed:       true,
+			RestoredPodUID: expectedUID,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(replacementPod, pmj).
+		WithStatusSubresource(&pmv1alpha1.PodMigrationJob{}).
+		Build()
+
+	r := &PodMigrationJobReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: jobName},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Errorf("Expected no requeue after malformed mismatch-since annotation fast-fail, got: %+v", res)
+	}
+
+	updatedPMJ := &pmv1alpha1.PodMigrationJob{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: jobName}, updatedPMJ)
+	if err != nil {
+		t.Fatalf("Failed to get PMJ: %v", err)
+	}
+	if updatedPMJ.Status.Phase != pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore {
+		t.Errorf("Expected phase %s, got %s", pmv1alpha1.PodMigrationJobPhaseSucceededWithoutRestore, updatedPMJ.Status.Phase)
+	}
+	if updatedPMJ.Status.CompletionTime == nil {
+		t.Errorf("Expected CompletionTime to be set")
+	}
+
+	restoredCond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Restored")
+	if restoredCond == nil || restoredCond.Reason != "ReplacementPodMismatch" || restoredCond.Status != metav1.ConditionFalse {
+		t.Errorf("Expected Restored condition False/ReplacementPodMismatch, got %+v", restoredCond)
+	}
+
+	readyCond := meta.FindStatusCondition(updatedPMJ.Status.Conditions, "Ready")
+	if readyCond == nil || readyCond.Reason != "ReplacementPodMismatch" || readyCond.Status != metav1.ConditionTrue {
+		t.Errorf("Expected Ready condition True/ReplacementPodMismatch, got %+v", readyCond)
 	}
 }

--- a/controller/internal/util/assignment.go
+++ b/controller/internal/util/assignment.go
@@ -23,6 +23,7 @@ const (
 	LabelJobCompletionIndex = batchv1.JobCompletionIndexAnnotation
 	LabelOriginPodName      = "pod-migration.gke.io/origin-pod-name"
 	AnnotationAssignedPMJ   = "pod-migration.gke.io/assigned-pmj"
+	AnnotationMismatchSince = "pod-migration.gke.io/mismatch-since"
 )
 
 // ResolveParentWorkload finds the parent owner details (ReplicaSet -> Deployment, Job, or StatefulSet).
@@ -132,7 +133,7 @@ func FindUnassignedActivePMJ(ctx context.Context, c client.Client, namespace, po
 		if phase == pmv1alpha1.PodMigrationJobPhasePending ||
 			phase == pmv1alpha1.PodMigrationJobPhaseSnapshotting ||
 			phase == pmv1alpha1.PodMigrationJobPhaseEvicting ||
-			phase == pmv1alpha1.PodMigrationJobPhaseSucceeded {
+			phase == pmv1alpha1.PodMigrationJobPhaseRestoring {
 			if !assignedPMJs[job.Name] {
 				return job.Name, nil
 			}

--- a/controller/internal/util/assignment_test.go
+++ b/controller/internal/util/assignment_test.go
@@ -480,7 +480,7 @@ func TestFindUnassignedActivePMJ_GenerationalWorkloadIsolation(t *testing.T) {
 						PodRef: corev1.LocalObjectReference{Name: "redis-0"},
 					},
 					Status: pmv1alpha1.PodMigrationJobStatus{
-						Phase: pmv1alpha1.PodMigrationJobPhaseSucceeded,
+						Phase: pmv1alpha1.PodMigrationJobPhaseRestoring,
 					},
 				},
 			},
@@ -507,7 +507,7 @@ func TestFindUnassignedActivePMJ_GenerationalWorkloadIsolation(t *testing.T) {
 						PodRef: corev1.LocalObjectReference{Name: "redis-0"},
 					},
 					Status: pmv1alpha1.PodMigrationJobStatus{
-						Phase: pmv1alpha1.PodMigrationJobPhaseSucceeded,
+						Phase: pmv1alpha1.PodMigrationJobPhaseRestoring,
 					},
 				},
 			},
@@ -534,7 +534,7 @@ func TestFindUnassignedActivePMJ_GenerationalWorkloadIsolation(t *testing.T) {
 						PodRef: corev1.LocalObjectReference{Name: "web-abc"},
 					},
 					Status: pmv1alpha1.PodMigrationJobStatus{
-						Phase: pmv1alpha1.PodMigrationJobPhaseSucceeded,
+						Phase: pmv1alpha1.PodMigrationJobPhaseRestoring,
 					},
 				},
 			},
@@ -574,7 +574,7 @@ func TestFindUnassignedActivePMJ_SingleUseConsumedGuard(t *testing.T) {
 		expectErr  bool
 	}{
 		{
-			name:       "Unconsumed Succeeded PMJ is eligible for adoption",
+			name:       "Unconsumed Restoring PMJ is eligible for adoption",
 			podName:    "redis-0",
 			parentName: "redis",
 			parentKind: "StatefulSet",
@@ -594,7 +594,7 @@ func TestFindUnassignedActivePMJ_SingleUseConsumedGuard(t *testing.T) {
 						PodRef: corev1.LocalObjectReference{Name: "redis-0"},
 					},
 					Status: pmv1alpha1.PodMigrationJobStatus{
-						Phase:    pmv1alpha1.PodMigrationJobPhaseSucceeded,
+						Phase:    pmv1alpha1.PodMigrationJobPhaseRestoring,
 						Consumed: false,
 					},
 				},
@@ -622,7 +622,7 @@ func TestFindUnassignedActivePMJ_SingleUseConsumedGuard(t *testing.T) {
 						PodRef: corev1.LocalObjectReference{Name: "redis-0"},
 					},
 					Status: pmv1alpha1.PodMigrationJobStatus{
-						Phase:          pmv1alpha1.PodMigrationJobPhaseSucceeded,
+						Phase:          pmv1alpha1.PodMigrationJobPhaseRestoring,
 						Consumed:       true, // Already consumed by prior replacement pod
 						RestoredPodUID: "prior-pod-uid",
 					},


### PR DESCRIPTION
## Summary
Implements GAP-1 (Issue #13) to introduce a first-class `Restoring` phase and verify actual memory restore outcomes on replacement pods, preventing premature `Succeeded` transitions upon volume detachment.

## Key Changes
1. **Lifecycle State Machine**: Added `Restoring` and `SucceededWithoutRestore` phases to `PodMigrationJob`.
2. **PMJ Reconciler**:
   - Transitions from `Evicting` to `Restoring` upon volume detach completion.
   - Actively monitors replacement pod until `PodReady` (`Succeeded`) or detects GKE runtime cold-start warning events (`SucceededWithoutRestore`).
   - Implements a 5-minute safety ceiling for pods that fail to initialize.
3. **Pod Gate Reconciler**:
   - Un-gates replacement pods upon `Restoring` or `Succeeded` and injects `podsnapshot.gke.io/ps-name`.
   - Guaranteed never to inject snapshot annotations when PMJ is in `Failed` phase (allowing clean cold starts).
4. **Generational Isolation & Fast-Fail**:
   - Strict `RestoredPodUID` assertion to prevent evaluating wrong pod instances.
   - 30-second fast-fail window (`AnnotationMismatchSince`) if a replacement pod is deleted and recreated by controllers.
5. **Least-Privilege RBAC**:
   - Added minimal read-only `events` permissions (`get`, `list`, `watch`) to `ClusterRole` for warning event inspection.

## Verification Evidence
- **Unit Tests (`go test -v -race -count=1 ./...`)**: **PASS** (0 data races detected across all packages).
- **Live E2E Validation on GKE 1.36.3 (`lpm-fresh-e2e`)**: **21/21 Workloads PASSED** (Databases, Caches, Message Brokers, Web Services, Rescheduled Jobs).

Closes #13